### PR TITLE
fix: regenerate CRD manifests

### DIFF
--- a/cmd/fsm-bootstrap/crds/config.flomesh.io_meshconfigs.yaml
+++ b/cmd/fsm-bootstrap/crds/config.flomesh.io_meshconfigs.yaml
@@ -358,9 +358,6 @@ spec:
                     description: MaxDataPlaneConnections defines the maximum allowed
                       data plane connections from a proxy sidecar to the FSM controller.
                     type: integer
-                  sidecarTimeout:
-                    description: connect/idle/read/write timeout
-                    type: integer
                   resources:
                     description: Resources defines the compute resources for the sidecar.
                     properties:
@@ -448,6 +445,10 @@ spec:
                     description: SidecarImage defines the container image used for
                       the proxy sidecar.
                     type: string
+                  sidecarTimeout:
+                    description: SidecarTimeout defines the connect/idle/read/write
+                      timeout.
+                    type: integer
                 required:
                 - enablePrivilegedInitContainer
                 type: object
@@ -921,9 +922,6 @@ spec:
                     description: MaxDataPlaneConnections defines the maximum allowed
                       data plane connections from a proxy sidecar to the FSM controller.
                     type: integer
-                  sidecarTimeout:
-                    description: connect/idle/read/write timeout
-                    type: integer
                   resources:
                     description: Resources defines the compute resources for the sidecar.
                     properties:
@@ -1012,6 +1010,10 @@ spec:
                     description: SidecarImage defines the container image used for
                       the proxy sidecar.
                     type: string
+                  sidecarTimeout:
+                    description: SidecarTimeout defines the connect/idle/read/write
+                      timeout.
+                    type: integer
                   tlsMaxProtocolVersion:
                     description: TLSMaxProtocolVersion defines the maximum TLS protocol
                       version that the sidecar supports. Valid TLS protocol versions
@@ -1779,9 +1781,6 @@ spec:
                     description: MaxDataPlaneConnections defines the maximum allowed
                       data plane connections from a proxy sidecar to the FSM controller.
                     type: integer
-                  sidecarTimeout:
-                    description: connect/idle/read/write timeout
-                    type: integer
                   resources:
                     description: Resources defines the compute resources for the sidecar.
                     properties:
@@ -1870,6 +1869,10 @@ spec:
                     description: SidecarImage defines the container image used for
                       the proxy sidecar.
                     type: string
+                  sidecarTimeout:
+                    description: SidecarTimeout defines the connect/idle/read/write
+                      timeout.
+                    type: integer
                   tlsMaxProtocolVersion:
                     description: TLSMaxProtocolVersion defines the maximum TLS protocol
                       version that the sidecar supports. Valid TLS protocol versions


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?