### PR TITLE
fix: invalid default TLS cert for ingress

### DIFF
--- a/pkg/manager/utils/tls.go
+++ b/pkg/manager/utils/tls.go
@@ -62,7 +62,7 @@ func IssueCertForIngress(basepath string, repoClient *repo.PipyRepoClient, certM
 	// 1. issue cert
 	cert, err := certMgr.IssueCertificate(
 		fmt.Sprintf("%s.%s.svc", constants.FSMIngressName, mc.GetFSMNamespace()),
-		certificate.Internal,
+		certificate.IngressGateway,
 		certificate.FullCNProvided())
 	if err != nil {
 		log.Error().Msgf("Issue certificate for ingress-pipy error: %s", err)
@@ -80,9 +80,9 @@ func IssueCertForIngress(basepath string, repoClient *repo.PipyRepoClient, certM
 		"listen":  mc.GetIngressTLSListenPort(),
 		"mTLS":    mc.IsIngressMTLSEnabled(),
 		"certificate": map[string]interface{}{
-			"cert": cert.GetCertificateChain(),
-			"key":  cert.GetPrivateKey(),
-			"ca":   cert.GetIssuingCA(),
+			"cert": string(cert.GetCertificateChain()),
+			"key":  string(cert.GetPrivateKey()),
+			"ca":   string(cert.GetIssuingCA()),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?