### PR TITLE
fix: overwrite curl image value in gateway and namespaced-ingress charts

### DIFF
--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
       - name: wait-controller
         image: {{ .Values.fsm.curlImage }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.fsm.image.pullPolicy }}
         command:
           - curl
           - {{ printf "http://fsm-controller.%s.svc.cluster.local:9091/health/ready" .Values.fsm.fsmNamespace }}

--- a/charts/namespaced-ingress/templates/deployment.yaml
+++ b/charts/namespaced-ingress/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
       - name: wait-controller
         image: {{ .Values.fsm.curlImage }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.fsm.image.pullPolicy }}
         command:
           - curl
           - {{ printf "http://fsm-controller.%s.svc.cluster.local:9091/health/ready" .Values.fsm.fsmNamespace }}

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -590,6 +590,11 @@ func (c *Client) ServiceLBImage() string {
 	return mcSpec.ServiceLB.Image
 }
 
+func (c *Client) GetCurlImage() string {
+	mcSpec := c.getMeshConfig().Spec
+	return mcSpec.Misc.CurlImage
+}
+
 // GetFLBSecretName returns the secret name for FLB
 func (c *Client) GetFLBSecretName() string {
 	return c.getMeshConfig().Spec.FLB.SecretName

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -80,6 +80,20 @@ func (mr *MockConfiguratorMockRecorder) GetConfigResyncInterval() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigResyncInterval", reflect.TypeOf((*MockConfigurator)(nil).GetConfigResyncInterval))
 }
 
+// GetCurlImage mocks base method.
+func (m *MockConfigurator) GetCurlImage() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurlImage")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetCurlImage indicates an expected call of GetCurlImage.
+func (mr *MockConfiguratorMockRecorder) GetCurlImage() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurlImage", reflect.TypeOf((*MockConfigurator)(nil).GetCurlImage))
+}
+
 // GetFGWLogLevel mocks base method.
 func (m *MockConfigurator) GetFGWLogLevel() string {
 	m.ctrl.T.Helper()

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -247,4 +247,7 @@ type Configurator interface {
 
 	// ServiceLBImage string returns the service-lb image
 	ServiceLBImage() string
+
+	// GetCurlImage returns the curl image
+	GetCurlImage() string
 }

--- a/pkg/manager/listeners/client.go
+++ b/pkg/manager/listeners/client.go
@@ -15,6 +15,11 @@ type client struct {
 	mc *configv1alpha3.MeshConfig
 }
 
+func (c *client) GetCurlImage() string {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (c *client) GetFGWLogLevel() string {
 	//TODO implement me
 	panic("implement me")


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?