### PR TITLE
fix: only filter endpoints by protocol of service port

### DIFF
--- a/pkg/controllers/flb/service_controller.go
+++ b/pkg/controllers/flb/service_controller.go
@@ -33,7 +33,6 @@ import (
 	"net/http"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -480,7 +479,7 @@ func (r *reconciler) deleteEntryFromFLB(ctx context.Context, svc *corev1.Service
 		setting := r.settings[svc.Namespace]
 		result := make(map[string][]string)
 		for _, port := range svc.Spec.Ports {
-			if !isSupportedProtocol(port) {
+			if !isSupportedProtocol(port.Protocol) {
 				continue
 			}
 
@@ -565,7 +564,7 @@ func (r *reconciler) getEndpoints(ctx context.Context, svc *corev1.Service, _ co
 	result := make(map[string][]string)
 
 	for _, port := range svc.Spec.Ports {
-		if !isSupportedProtocol(port) {
+		if !isSupportedProtocol(port.Protocol) {
 			continue
 		}
 
@@ -576,11 +575,7 @@ func (r *reconciler) getEndpoints(ctx context.Context, svc *corev1.Service, _ co
 			matchedPortNameFound := false
 
 			for i, epPort := range ss.Ports {
-				if epPort.Protocol != corev1.ProtocolTCP {
-					continue
-				}
-
-				var targetPort int32
+				targetPort := int32(0)
 
 				if port.Name == "" {
 					// port.Name is optional if there is only one port
@@ -600,7 +595,7 @@ func (r *reconciler) getEndpoints(ctx context.Context, svc *corev1.Service, _ co
 				}
 
 				for _, epAddress := range ss.Addresses {
-					ep := net.JoinHostPort(epAddress.IP, strconv.Itoa(int(targetPort)))
+					ep := net.JoinHostPort(epAddress.IP, fmt.Sprintf("%d", targetPort))
 					result[svcKey] = append(result[svcKey], ep)
 				}
 			}
@@ -616,8 +611,8 @@ func (r *reconciler) getEndpoints(ctx context.Context, svc *corev1.Service, _ co
 	return result, nil
 }
 
-func isSupportedProtocol(port corev1.ServicePort) bool {
-	switch port.Protocol {
+func isSupportedProtocol(protocol corev1.Protocol) bool {
+	switch protocol {
 	case corev1.ProtocolTCP, corev1.ProtocolUDP:
 		return true
 	default:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?