### PR TITLE
feat: sort traffic match conditions of route

### DIFF
--- a/pkg/controllers/gateway/v1beta1/gateway_controller.go
+++ b/pkg/controllers/gateway/v1beta1/gateway_controller.go
@@ -201,7 +201,7 @@ func (r *gatewayReconciler) updateGatewayStatus(ctx context.Context, gateway *gw
 
 	sort.Slice(validGateways, func(i, j int) bool {
 		if validGateways[i].CreationTimestamp.Time.Equal(validGateways[j].CreationTimestamp.Time) {
-			return validGateways[i].Name < validGateways[j].Name
+			return client.ObjectKeyFromObject(validGateways[i]).String() < client.ObjectKeyFromObject(validGateways[j]).String()
 		}
 
 		return validGateways[i].CreationTimestamp.Time.Before(validGateways[j].CreationTimestamp.Time)

--- a/pkg/controllers/policyattachment/v1alpha1/circuitbreakingpolicy_controller.go
+++ b/pkg/controllers/policyattachment/v1alpha1/circuitbreakingpolicy_controller.go
@@ -173,7 +173,7 @@ func (r *circuitBreakingPolicyReconciler) getStatusCondition(ctx context.Context
 
 		sort.Slice(circuitBreakings, func(i, j int) bool {
 			if circuitBreakings[i].CreationTimestamp.Time.Equal(circuitBreakings[j].CreationTimestamp.Time) {
-				return circuitBreakings[i].Name < circuitBreakings[j].Name
+				return client.ObjectKeyFromObject(&circuitBreakings[i]).String() < client.ObjectKeyFromObject(&circuitBreakings[j]).String()
 			}
 
 			return circuitBreakings[i].CreationTimestamp.Time.Before(circuitBreakings[j].CreationTimestamp.Time)
@@ -227,23 +227,23 @@ func (r *circuitBreakingPolicyReconciler) getStatusCondition(ctx context.Context
 			}
 		}
 
-		sessionStickies := make([]gwpav1alpha1.CircuitBreakingPolicy, 0)
+		circuitBreakings := make([]gwpav1alpha1.CircuitBreakingPolicy, 0)
 		for _, p := range circuitBreakingPolicyList.Items {
 			if gwutils.IsAcceptedPolicyAttachment(p.Status.Conditions) &&
 				gwutils.IsRefToTarget(p.Spec.TargetRef, svcimp) {
-				sessionStickies = append(sessionStickies, p)
+				circuitBreakings = append(circuitBreakings, p)
 			}
 		}
 
-		sort.Slice(sessionStickies, func(i, j int) bool {
-			if sessionStickies[i].CreationTimestamp.Time.Equal(sessionStickies[j].CreationTimestamp.Time) {
-				return sessionStickies[i].Name < sessionStickies[j].Name
+		sort.Slice(circuitBreakings, func(i, j int) bool {
+			if circuitBreakings[i].CreationTimestamp.Time.Equal(circuitBreakings[j].CreationTimestamp.Time) {
+				return client.ObjectKeyFromObject(&circuitBreakings[i]).String() < client.ObjectKeyFromObject(&circuitBreakings[j]).String()
 			}
 
-			return sessionStickies[i].CreationTimestamp.Time.Before(sessionStickies[j].CreationTimestamp.Time)
+			return circuitBreakings[i].CreationTimestamp.Time.Before(circuitBreakings[j].CreationTimestamp.Time)
 		})
 
-		if conflict := r.getConflictedPolicyByServiceImport(policy, sessionStickies, svcimp); conflict != nil {
+		if conflict := r.getConflictedPolicyByServiceImport(policy, circuitBreakings, svcimp); conflict != nil {
 			return metav1.Condition{
 				Type:               string(gwv1alpha2.PolicyConditionAccepted),
 				Status:             metav1.ConditionFalse,

--- a/pkg/controllers/policyattachment/v1alpha1/faultinjectionpolicy_controller.go
+++ b/pkg/controllers/policyattachment/v1alpha1/faultinjectionpolicy_controller.go
@@ -246,14 +246,14 @@ func (r *faultInjectionPolicyReconciler) getConflictedHostnamesOrRouteBasedFault
 	}
 	sort.Slice(hostnamesFaultInjections, func(i, j int) bool {
 		if hostnamesFaultInjections[i].CreationTimestamp.Time.Equal(hostnamesFaultInjections[j].CreationTimestamp.Time) {
-			return hostnamesFaultInjections[i].Name < hostnamesFaultInjections[j].Name
+			return client.ObjectKeyFromObject(&hostnamesFaultInjections[i]).String() < client.ObjectKeyFromObject(&hostnamesFaultInjections[j]).String()
 		}
 
 		return hostnamesFaultInjections[i].CreationTimestamp.Time.Before(hostnamesFaultInjections[j].CreationTimestamp.Time)
 	})
 	sort.Slice(routeFaultInjections, func(i, j int) bool {
 		if routeFaultInjections[i].CreationTimestamp.Time.Equal(routeFaultInjections[j].CreationTimestamp.Time) {
-			return routeFaultInjections[i].Name < routeFaultInjections[j].Name
+			return client.ObjectKeyFromObject(&routeFaultInjections[i]).String() < client.ObjectKeyFromObject(&routeFaultInjections[j]).String()
 		}
 
 		return routeFaultInjections[i].CreationTimestamp.Time.Before(routeFaultInjections[j].CreationTimestamp.Time)

--- a/pkg/controllers/policyattachment/v1alpha1/gatewaytlspolicy_controller.go
+++ b/pkg/controllers/policyattachment/v1alpha1/gatewaytlspolicy_controller.go
@@ -28,7 +28,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/flomesh-io/fsm/pkg/gateway/policy/utils/gatewaytls"
 
@@ -152,7 +155,24 @@ func (r *gatewayTLSPolicyReconciler) getStatusCondition(ctx context.Context, pol
 				Message:            fmt.Sprintf("Failed to list GatewayTLSPolicies: %s", err),
 			}
 		}
-		if conflict := r.getConflictedPort(gateway, policy, gatewayTLSPolicyList); conflict != nil {
+
+		gatewayTLSPolicies := make([]gwpav1alpha1.GatewayTLSPolicy, 0)
+		for _, p := range gatewayTLSPolicyList.Items {
+			if gwutils.IsAcceptedPolicyAttachment(p.Status.Conditions) &&
+				gwutils.IsRefToTarget(p.Spec.TargetRef, gateway) {
+				gatewayTLSPolicies = append(gatewayTLSPolicies, p)
+			}
+		}
+
+		sort.Slice(gatewayTLSPolicies, func(i, j int) bool {
+			if gatewayTLSPolicies[i].CreationTimestamp.Time.Equal(gatewayTLSPolicies[j].CreationTimestamp.Time) {
+				return client.ObjectKeyFromObject(&gatewayTLSPolicies[i]).String() < client.ObjectKeyFromObject(&gatewayTLSPolicies[j]).String()
+			}
+
+			return gatewayTLSPolicies[i].CreationTimestamp.Time.Before(gatewayTLSPolicies[j].CreationTimestamp.Time)
+		})
+
+		if conflict := r.getConflictedPort(gateway, policy, gatewayTLSPolicies); conflict != nil {
 			return metav1.Condition{
 				Type:               string(gwv1alpha2.PolicyConditionAccepted),
 				Status:             metav1.ConditionFalse,
@@ -183,16 +203,14 @@ func (r *gatewayTLSPolicyReconciler) getStatusCondition(ctx context.Context, pol
 	}
 }
 
-func (r *gatewayTLSPolicyReconciler) getConflictedPort(gateway *gwv1beta1.Gateway, gatewayTLSPolicy *gwpav1alpha1.GatewayTLSPolicy, allGatewayTLSPolicies *gwpav1alpha1.GatewayTLSPolicyList) *types.NamespacedName {
+func (r *gatewayTLSPolicyReconciler) getConflictedPort(gateway *gwv1beta1.Gateway, gatewayTLSPolicy *gwpav1alpha1.GatewayTLSPolicy, allGatewayTLSPolicies []gwpav1alpha1.GatewayTLSPolicy) *types.NamespacedName {
 	if len(gatewayTLSPolicy.Spec.Ports) == 0 {
 		return nil
 	}
 
 	validListeners := gwutils.GetValidListenersFromGateway(gateway)
-	for _, pr := range allGatewayTLSPolicies.Items {
-		if gwutils.IsAcceptedPolicyAttachment(pr.Status.Conditions) &&
-			gwutils.IsRefToTarget(pr.Spec.TargetRef, gateway) &&
-			len(pr.Spec.Ports) > 0 {
+	for _, pr := range allGatewayTLSPolicies {
+		if len(pr.Spec.Ports) > 0 {
 			for _, listener := range validListeners {
 				r1 := gatewaytls.GetGatewayTLSConfigIfPortMatchesPolicy(listener.Port, pr)
 				if r1 == nil {

--- a/pkg/controllers/policyattachment/v1alpha1/healthcheckpolicy_controller.go
+++ b/pkg/controllers/policyattachment/v1alpha1/healthcheckpolicy_controller.go
@@ -173,7 +173,7 @@ func (r *healthCheckPolicyReconciler) getStatusCondition(ctx context.Context, po
 
 		sort.Slice(healthChecks, func(i, j int) bool {
 			if healthChecks[i].CreationTimestamp.Time.Equal(healthChecks[j].CreationTimestamp.Time) {
-				return healthChecks[i].Name < healthChecks[j].Name
+				return client.ObjectKeyFromObject(&healthChecks[i]).String() < client.ObjectKeyFromObject(&healthChecks[j]).String()
 			}
 
 			return healthChecks[i].CreationTimestamp.Time.Before(healthChecks[j].CreationTimestamp.Time)
@@ -227,23 +227,23 @@ func (r *healthCheckPolicyReconciler) getStatusCondition(ctx context.Context, po
 			}
 		}
 
-		sessionStickies := make([]gwpav1alpha1.HealthCheckPolicy, 0)
+		healthCheckPolicies := make([]gwpav1alpha1.HealthCheckPolicy, 0)
 		for _, p := range healthCheckPolicyList.Items {
 			if gwutils.IsAcceptedPolicyAttachment(p.Status.Conditions) &&
 				gwutils.IsRefToTarget(p.Spec.TargetRef, svcimp) {
-				sessionStickies = append(sessionStickies, p)
+				healthCheckPolicies = append(healthCheckPolicies, p)
 			}
 		}
 
-		sort.Slice(sessionStickies, func(i, j int) bool {
-			if sessionStickies[i].CreationTimestamp.Time.Equal(sessionStickies[j].CreationTimestamp.Time) {
-				return sessionStickies[i].Name < sessionStickies[j].Name
+		sort.Slice(healthCheckPolicies, func(i, j int) bool {
+			if healthCheckPolicies[i].CreationTimestamp.Time.Equal(healthCheckPolicies[j].CreationTimestamp.Time) {
+				return client.ObjectKeyFromObject(&healthCheckPolicies[i]).String() < client.ObjectKeyFromObject(&healthCheckPolicies[j]).String()
 			}
 
-			return sessionStickies[i].CreationTimestamp.Time.Before(sessionStickies[j].CreationTimestamp.Time)
+			return healthCheckPolicies[i].CreationTimestamp.Time.Before(healthCheckPolicies[j].CreationTimestamp.Time)
 		})
 
-		if conflict := r.getConflictedPolicyByServiceImport(policy, sessionStickies, svcimp); conflict != nil {
+		if conflict := r.getConflictedPolicyByServiceImport(policy, healthCheckPolicies, svcimp); conflict != nil {
 			return metav1.Condition{
 				Type:               string(gwv1alpha2.PolicyConditionAccepted),
 				Status:             metav1.ConditionFalse,

--- a/pkg/controllers/policyattachment/v1alpha1/loadbalancerpolicy_controller.go
+++ b/pkg/controllers/policyattachment/v1alpha1/loadbalancerpolicy_controller.go
@@ -172,7 +172,7 @@ func (r *loadBalancerPolicyReconciler) getStatusCondition(ctx context.Context, p
 
 		sort.Slice(loadBalancers, func(i, j int) bool {
 			if loadBalancers[i].CreationTimestamp.Time.Equal(loadBalancers[j].CreationTimestamp.Time) {
-				return loadBalancers[i].Name < loadBalancers[j].Name
+				return client.ObjectKeyFromObject(&loadBalancers[i]).String() < client.ObjectKeyFromObject(&loadBalancers[j]).String()
 			}
 
 			return loadBalancers[i].CreationTimestamp.Time.Before(loadBalancers[j].CreationTimestamp.Time)
@@ -236,7 +236,7 @@ func (r *loadBalancerPolicyReconciler) getStatusCondition(ctx context.Context, p
 
 		sort.Slice(loadBalancers, func(i, j int) bool {
 			if loadBalancers[i].CreationTimestamp.Time.Equal(loadBalancers[j].CreationTimestamp.Time) {
-				return loadBalancers[i].Name < loadBalancers[j].Name
+				return client.ObjectKeyFromObject(&loadBalancers[i]).String() < client.ObjectKeyFromObject(&loadBalancers[j]).String()
 			}
 
 			return loadBalancers[i].CreationTimestamp.Time.Before(loadBalancers[j].CreationTimestamp.Time)

--- a/pkg/controllers/policyattachment/v1alpha1/ratelimitpolicy_controller.go
+++ b/pkg/controllers/policyattachment/v1alpha1/ratelimitpolicy_controller.go
@@ -155,7 +155,24 @@ func (r *rateLimitPolicyReconciler) getStatusCondition(ctx context.Context, poli
 				Message:            fmt.Sprintf("Failed to list RateLimitPolicies: %s", err),
 			}
 		}
-		if conflict := r.getConflictedPort(gateway, policy, rateLimitPolicyList); conflict != nil {
+
+		rateLimitPolicies := make([]gwpav1alpha1.RateLimitPolicy, 0)
+		for _, p := range rateLimitPolicyList.Items {
+			if gwutils.IsAcceptedPolicyAttachment(p.Status.Conditions) &&
+				gwutils.IsRefToTarget(p.Spec.TargetRef, gateway) {
+				rateLimitPolicies = append(rateLimitPolicies, p)
+			}
+		}
+
+		sort.Slice(rateLimitPolicies, func(i, j int) bool {
+			if rateLimitPolicies[i].CreationTimestamp.Time.Equal(rateLimitPolicies[j].CreationTimestamp.Time) {
+				return client.ObjectKeyFromObject(&rateLimitPolicies[i]).String() < client.ObjectKeyFromObject(&rateLimitPolicies[j]).String()
+			}
+
+			return rateLimitPolicies[i].CreationTimestamp.Time.Before(rateLimitPolicies[j].CreationTimestamp.Time)
+		})
+
+		if conflict := r.getConflictedPort(gateway, policy, rateLimitPolicies); conflict != nil {
 			return metav1.Condition{
 				Type:               string(gwv1alpha2.PolicyConditionAccepted),
 				Status:             metav1.ConditionFalse,
@@ -291,14 +308,14 @@ func (r *rateLimitPolicyReconciler) getConflictedHostnamesOrRouteBasedRateLimitP
 	}
 	sort.Slice(hostnamesRateLimits, func(i, j int) bool {
 		if hostnamesRateLimits[i].CreationTimestamp.Time.Equal(hostnamesRateLimits[j].CreationTimestamp.Time) {
-			return hostnamesRateLimits[i].Name < hostnamesRateLimits[j].Name
+			return client.ObjectKeyFromObject(&hostnamesRateLimits[i]).String() < client.ObjectKeyFromObject(&hostnamesRateLimits[j]).String()
 		}
 
 		return hostnamesRateLimits[i].CreationTimestamp.Time.Before(hostnamesRateLimits[j].CreationTimestamp.Time)
 	})
 	sort.Slice(routeRateLimits, func(i, j int) bool {
 		if routeRateLimits[i].CreationTimestamp.Time.Equal(routeRateLimits[j].CreationTimestamp.Time) {
-			return routeRateLimits[i].Name < routeRateLimits[j].Name
+			return client.ObjectKeyFromObject(&routeRateLimits[i]).String() < client.ObjectKeyFromObject(&routeRateLimits[j]).String()
 		}
 
 		return routeRateLimits[i].CreationTimestamp.Time.Before(routeRateLimits[j].CreationTimestamp.Time)
@@ -461,16 +478,14 @@ func (r *rateLimitPolicyReconciler) getConflictedRouteBasedRateLimitPolicy(route
 	return nil
 }
 
-func (r *rateLimitPolicyReconciler) getConflictedPort(gateway *gwv1beta1.Gateway, rateLimitPolicy *gwpav1alpha1.RateLimitPolicy, allRateLimitPolicies *gwpav1alpha1.RateLimitPolicyList) *types.NamespacedName {
+func (r *rateLimitPolicyReconciler) getConflictedPort(gateway *gwv1beta1.Gateway, rateLimitPolicy *gwpav1alpha1.RateLimitPolicy, allRateLimitPolicies []gwpav1alpha1.RateLimitPolicy) *types.NamespacedName {
 	if len(rateLimitPolicy.Spec.Ports) == 0 {
 		return nil
 	}
 
 	validListeners := gwutils.GetValidListenersFromGateway(gateway)
-	for _, pr := range allRateLimitPolicies.Items {
-		if gwutils.IsAcceptedPolicyAttachment(pr.Status.Conditions) &&
-			gwutils.IsRefToTarget(pr.Spec.TargetRef, gateway) &&
-			len(pr.Spec.Ports) > 0 {
+	for _, pr := range allRateLimitPolicies {
+		if len(pr.Spec.Ports) > 0 {
 			for _, listener := range validListeners {
 				r1 := ratelimit.GetRateLimitIfPortMatchesPolicy(listener.Port, pr)
 				if r1 == nil {

--- a/pkg/controllers/policyattachment/v1alpha1/retrypolicy_controller.go
+++ b/pkg/controllers/policyattachment/v1alpha1/retrypolicy_controller.go
@@ -163,23 +163,23 @@ func (r *retryPolicyReconciler) getStatusCondition(ctx context.Context, policy *
 			}
 		}
 
-		sessionStickies := make([]gwpav1alpha1.RetryPolicy, 0)
+		retryPolicies := make([]gwpav1alpha1.RetryPolicy, 0)
 		for _, p := range retryPolicyList.Items {
 			if gwutils.IsAcceptedPolicyAttachment(p.Status.Conditions) &&
 				gwutils.IsRefToTarget(p.Spec.TargetRef, svc) {
-				sessionStickies = append(sessionStickies, p)
+				retryPolicies = append(retryPolicies, p)
 			}
 		}
 
-		sort.Slice(sessionStickies, func(i, j int) bool {
-			if sessionStickies[i].CreationTimestamp.Time.Equal(sessionStickies[j].CreationTimestamp.Time) {
-				return sessionStickies[i].Name < sessionStickies[j].Name
+		sort.Slice(retryPolicies, func(i, j int) bool {
+			if retryPolicies[i].CreationTimestamp.Time.Equal(retryPolicies[j].CreationTimestamp.Time) {
+				return client.ObjectKeyFromObject(&retryPolicies[i]).String() < client.ObjectKeyFromObject(&retryPolicies[j]).String()
 			}
 
-			return sessionStickies[i].CreationTimestamp.Time.Before(sessionStickies[j].CreationTimestamp.Time)
+			return retryPolicies[i].CreationTimestamp.Time.Before(retryPolicies[j].CreationTimestamp.Time)
 		})
 
-		if conflict := r.getConflictedPolicyByService(policy, sessionStickies, svc); conflict != nil {
+		if conflict := r.getConflictedPolicyByService(policy, retryPolicies, svc); conflict != nil {
 			return metav1.Condition{
 				Type:               string(gwv1alpha2.PolicyConditionAccepted),
 				Status:             metav1.ConditionFalse,
@@ -227,23 +227,23 @@ func (r *retryPolicyReconciler) getStatusCondition(ctx context.Context, policy *
 			}
 		}
 
-		sessionStickies := make([]gwpav1alpha1.RetryPolicy, 0)
+		retryPolicies := make([]gwpav1alpha1.RetryPolicy, 0)
 		for _, p := range retryPolicyList.Items {
 			if gwutils.IsAcceptedPolicyAttachment(p.Status.Conditions) &&
 				gwutils.IsRefToTarget(p.Spec.TargetRef, svcimp) {
-				sessionStickies = append(sessionStickies, p)
+				retryPolicies = append(retryPolicies, p)
 			}
 		}
 
-		sort.Slice(sessionStickies, func(i, j int) bool {
-			if sessionStickies[i].CreationTimestamp.Time.Equal(sessionStickies[j].CreationTimestamp.Time) {
-				return sessionStickies[i].Name < sessionStickies[j].Name
+		sort.Slice(retryPolicies, func(i, j int) bool {
+			if retryPolicies[i].CreationTimestamp.Time.Equal(retryPolicies[j].CreationTimestamp.Time) {
+				return client.ObjectKeyFromObject(&retryPolicies[i]).String() < client.ObjectKeyFromObject(&retryPolicies[j]).String()
 			}
 
-			return sessionStickies[i].CreationTimestamp.Time.Before(sessionStickies[j].CreationTimestamp.Time)
+			return retryPolicies[i].CreationTimestamp.Time.Before(retryPolicies[j].CreationTimestamp.Time)
 		})
 
-		if conflict := r.getConflictedPolicyByServiceImport(policy, sessionStickies, svcimp); conflict != nil {
+		if conflict := r.getConflictedPolicyByServiceImport(policy, retryPolicies, svcimp); conflict != nil {
 			return metav1.Condition{
 				Type:               string(gwv1alpha2.PolicyConditionAccepted),
 				Status:             metav1.ConditionFalse,

--- a/pkg/controllers/policyattachment/v1alpha1/sessionstickypolicy_controller.go
+++ b/pkg/controllers/policyattachment/v1alpha1/sessionstickypolicy_controller.go
@@ -173,7 +173,7 @@ func (r *sessionStickyPolicyReconciler) getStatusCondition(ctx context.Context, 
 
 		sort.Slice(sessionStickies, func(i, j int) bool {
 			if sessionStickies[i].CreationTimestamp.Time.Equal(sessionStickies[j].CreationTimestamp.Time) {
-				return sessionStickies[i].Name < sessionStickies[j].Name
+				return client.ObjectKeyFromObject(&sessionStickies[i]).String() < client.ObjectKeyFromObject(&sessionStickies[j]).String()
 			}
 
 			return sessionStickies[i].CreationTimestamp.Time.Before(sessionStickies[j].CreationTimestamp.Time)
@@ -237,7 +237,7 @@ func (r *sessionStickyPolicyReconciler) getStatusCondition(ctx context.Context, 
 
 		sort.Slice(sessionStickies, func(i, j int) bool {
 			if sessionStickies[i].CreationTimestamp.Time.Equal(sessionStickies[j].CreationTimestamp.Time) {
-				return sessionStickies[i].Name < sessionStickies[j].Name
+				return client.ObjectKeyFromObject(&sessionStickies[i]).String() < client.ObjectKeyFromObject(&sessionStickies[j]).String()
 			}
 
 			return sessionStickies[i].CreationTimestamp.Time.Before(sessionStickies[j].CreationTimestamp.Time)

--- a/pkg/controllers/policyattachment/v1alpha1/upstreamtlspolicy_controller.go
+++ b/pkg/controllers/policyattachment/v1alpha1/upstreamtlspolicy_controller.go
@@ -163,23 +163,23 @@ func (r *upstreamTLSPolicyReconciler) getStatusCondition(ctx context.Context, po
 			}
 		}
 
-		sessionStickies := make([]gwpav1alpha1.UpstreamTLSPolicy, 0)
+		upstreamTLSPolicies := make([]gwpav1alpha1.UpstreamTLSPolicy, 0)
 		for _, p := range upstreamTLSPolicyList.Items {
 			if gwutils.IsAcceptedPolicyAttachment(p.Status.Conditions) &&
 				gwutils.IsRefToTarget(p.Spec.TargetRef, svc) {
-				sessionStickies = append(sessionStickies, p)
+				upstreamTLSPolicies = append(upstreamTLSPolicies, p)
 			}
 		}
 
-		sort.Slice(sessionStickies, func(i, j int) bool {
-			if sessionStickies[i].CreationTimestamp.Time.Equal(sessionStickies[j].CreationTimestamp.Time) {
-				return sessionStickies[i].Name < sessionStickies[j].Name
+		sort.Slice(upstreamTLSPolicies, func(i, j int) bool {
+			if upstreamTLSPolicies[i].CreationTimestamp.Time.Equal(upstreamTLSPolicies[j].CreationTimestamp.Time) {
+				return client.ObjectKeyFromObject(&upstreamTLSPolicies[i]).String() < client.ObjectKeyFromObject(&upstreamTLSPolicies[j]).String()
 			}
 
-			return sessionStickies[i].CreationTimestamp.Time.Before(sessionStickies[j].CreationTimestamp.Time)
+			return upstreamTLSPolicies[i].CreationTimestamp.Time.Before(upstreamTLSPolicies[j].CreationTimestamp.Time)
 		})
 
-		if conflict := r.getConflictedPolicyByService(policy, sessionStickies, svc); conflict != nil {
+		if conflict := r.getConflictedPolicyByService(policy, upstreamTLSPolicies, svc); conflict != nil {
 			return metav1.Condition{
 				Type:               string(gwv1alpha2.PolicyConditionAccepted),
 				Status:             metav1.ConditionFalse,
@@ -227,23 +227,23 @@ func (r *upstreamTLSPolicyReconciler) getStatusCondition(ctx context.Context, po
 			}
 		}
 
-		sessionStickies := make([]gwpav1alpha1.UpstreamTLSPolicy, 0)
+		upstreamTLSPolicies := make([]gwpav1alpha1.UpstreamTLSPolicy, 0)
 		for _, p := range upstreamTLSPolicyList.Items {
 			if gwutils.IsAcceptedPolicyAttachment(p.Status.Conditions) &&
 				gwutils.IsRefToTarget(p.Spec.TargetRef, svcimp) {
-				sessionStickies = append(sessionStickies, p)
+				upstreamTLSPolicies = append(upstreamTLSPolicies, p)
 			}
 		}
 
-		sort.Slice(sessionStickies, func(i, j int) bool {
-			if sessionStickies[i].CreationTimestamp.Time.Equal(sessionStickies[j].CreationTimestamp.Time) {
-				return sessionStickies[i].Name < sessionStickies[j].Name
+		sort.Slice(upstreamTLSPolicies, func(i, j int) bool {
+			if upstreamTLSPolicies[i].CreationTimestamp.Time.Equal(upstreamTLSPolicies[j].CreationTimestamp.Time) {
+				return client.ObjectKeyFromObject(&upstreamTLSPolicies[i]).String() < client.ObjectKeyFromObject(&upstreamTLSPolicies[j]).String()
 			}
 
-			return sessionStickies[i].CreationTimestamp.Time.Before(sessionStickies[j].CreationTimestamp.Time)
+			return upstreamTLSPolicies[i].CreationTimestamp.Time.Before(upstreamTLSPolicies[j].CreationTimestamp.Time)
 		})
 
-		if conflict := r.getConflictedPolicyByServiceImport(policy, sessionStickies, svcimp); conflict != nil {
+		if conflict := r.getConflictedPolicyByServiceImport(policy, upstreamTLSPolicies, svcimp); conflict != nil {
 			return metav1.Condition{
 				Type:               string(gwv1alpha2.PolicyConditionAccepted),
 				Status:             metav1.ConditionFalse,

--- a/pkg/gateway/cache/config.go
+++ b/pkg/gateway/cache/config.go
@@ -241,47 +241,23 @@ func (c *GatewayCache) routeRules(gw *gwv1beta1.Gateway, validListeners []gwtype
 	services := make(map[string]serviceInfo)
 
 	log.Debug().Msgf("Processing %d HTTPRoutes", len(c.httproutes))
-	for key := range c.httproutes {
-		httpRoute, err := c.getHTTPRouteFromCache(key)
-		if err != nil {
-			log.Error().Msgf("Failed to get HTTPRoute %s: %s", key, err)
-			continue
-		}
-
+	for _, httpRoute := range c.getSortedHTTPRoutes() {
 		processHTTPRoute(gw, validListeners, httpRoute, policies, rules, services)
 	}
 
 	log.Debug().Msgf("Processing %d GRPCRoutes", len(c.grpcroutes))
-	for key := range c.grpcroutes {
-		grpcRoute, err := c.getGRPCRouteFromCache(key)
-		if err != nil {
-			log.Error().Msgf("Failed to get GRPCRoute %s: %s", key, err)
-			continue
-		}
-
+	for _, grpcRoute := range c.getSortedGRPCRoutes() {
 		processGRPCRoute(gw, validListeners, grpcRoute, policies, rules, services)
 	}
 
 	log.Debug().Msgf("Processing %d TLSRoutes", len(c.tlsroutes))
-	for key := range c.tlsroutes {
-		tlsRoute, err := c.getTLSRouteFromCache(key)
-		if err != nil {
-			log.Error().Msgf("Failed to get TLSRoute %s: %s", key, err)
-			continue
-		}
-
+	for _, tlsRoute := range c.getSortedTLSRoutes() {
 		processTLSRoute(gw, validListeners, tlsRoute, rules)
 		processTLSBackends(tlsRoute, services)
 	}
 
 	log.Debug().Msgf("Processing %d TCPRoutes", len(c.tcproutes))
-	for key := range c.tcproutes {
-		tcpRoute, err := c.getTCPRouteFromCache(key)
-		if err != nil {
-			log.Error().Msgf("Failed to get TCPRoute %s: %s", key, err)
-			continue
-		}
-
+	for _, tcpRoute := range c.getSortedTCPRoutes() {
 		processTCPRoute(gw, validListeners, tcpRoute, rules)
 		processTCPBackends(tcpRoute, services)
 	}

--- a/pkg/gateway/cache/grpcroute.go
+++ b/pkg/gateway/cache/grpcroute.go
@@ -113,5 +113,6 @@ func generateGRPCRouteCfg(grpcRoute *gwv1alpha2.GRPCRoute, routePolicies routePo
 		}
 	}
 
+	grpcSpec.Sort()
 	return grpcSpec
 }

--- a/pkg/gateway/cache/httproute.go
+++ b/pkg/gateway/cache/httproute.go
@@ -121,5 +121,7 @@ func generateHTTPRouteConfig(httpRoute *gwv1beta1.HTTPRoute, routePolicies route
 			httpSpec.Matches = append(httpSpec.Matches, *match)
 		}
 	}
+
+	httpSpec.Sort()
 	return httpSpec
 }

--- a/pkg/gateway/cache/policies.go
+++ b/pkg/gateway/cache/policies.go
@@ -114,7 +114,7 @@ func (c *GatewayCache) rateLimits() map[RateLimitPolicyMatchType][]gwpav1alpha1.
 	for matchType, policies := range rateLimits {
 		sort.Slice(policies, func(i, j int) bool {
 			if policies[i].CreationTimestamp.Time.Equal(policies[j].CreationTimestamp.Time) {
-				return policies[i].Name < policies[j].Name
+				return client.ObjectKeyFromObject(&policies[i]).String() < client.ObjectKeyFromObject(&policies[j]).String()
 			}
 
 			return policies[i].CreationTimestamp.Time.Before(policies[j].CreationTimestamp.Time)
@@ -164,7 +164,7 @@ func (c *GatewayCache) accessControls() map[AccessControlPolicyMatchType][]gwpav
 	for matchType, policies := range accessControls {
 		sort.Slice(policies, func(i, j int) bool {
 			if policies[i].CreationTimestamp.Time.Equal(policies[j].CreationTimestamp.Time) {
-				return policies[i].Name < policies[j].Name
+				return client.ObjectKeyFromObject(&policies[i]).String() < client.ObjectKeyFromObject(&policies[j]).String()
 			}
 
 			return policies[i].CreationTimestamp.Time.Before(policies[j].CreationTimestamp.Time)
@@ -211,7 +211,7 @@ func (c *GatewayCache) faultInjections() map[FaultInjectionPolicyMatchType][]gwp
 	for matchType, policies := range faultInjections {
 		sort.Slice(policies, func(i, j int) bool {
 			if policies[i].CreationTimestamp.Time.Equal(policies[j].CreationTimestamp.Time) {
-				return policies[i].Name < policies[j].Name
+				return client.ObjectKeyFromObject(&policies[i]).String() < client.ObjectKeyFromObject(&policies[j]).String()
 			}
 
 			return policies[i].CreationTimestamp.Time.Before(policies[j].CreationTimestamp.Time)

--- a/pkg/gateway/cache/utils.go
+++ b/pkg/gateway/cache/utils.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"reflect"
 
 	"golang.org/x/exp/slices"
 
@@ -328,7 +329,18 @@ func mergeL7RouteRule(rule1 routecfg.L7RouteRule, rule2 routecfg.L7RouteRule) ro
 			case *routecfg.GRPCRouteRuleSpec:
 				switch r2 := rule.(type) {
 				case *routecfg.GRPCRouteRuleSpec:
+					if !reflect.DeepEqual(r1.RateLimit, r2.RateLimit) {
+						continue
+					}
+					if !reflect.DeepEqual(r1.AccessControlLists, r2.AccessControlLists) {
+						continue
+					}
+					if !reflect.DeepEqual(r1.FaultInjection, r2.FaultInjection) {
+						continue
+					}
+
 					r1.Matches = append(r1.Matches, r2.Matches...)
+					r1.Sort()
 					mergedRule[hostname] = r1
 				default:
 					log.Error().Msgf("%s has been already mapped to RouteRule[%s] %v, current RouteRule %v will be dropped.", hostname, r1.RouteType, r1, r2)
@@ -336,7 +348,18 @@ func mergeL7RouteRule(rule1 routecfg.L7RouteRule, rule2 routecfg.L7RouteRule) ro
 			case *routecfg.HTTPRouteRuleSpec:
 				switch r2 := rule.(type) {
 				case *routecfg.HTTPRouteRuleSpec:
+					if !reflect.DeepEqual(r1.RateLimit, r2.RateLimit) {
+						continue
+					}
+					if !reflect.DeepEqual(r1.AccessControlLists, r2.AccessControlLists) {
+						continue
+					}
+					if !reflect.DeepEqual(r1.FaultInjection, r2.FaultInjection) {
+						continue
+					}
+
 					r1.Matches = append(r1.Matches, r2.Matches...)
+					r1.Sort()
 					mergedRule[hostname] = r1
 				default:
 					log.Error().Msgf("%s has been already mapped to RouteRule[%s] %v, current RouteRule %v will be dropped.", hostname, r1.RouteType, r1, r2)


### PR DESCRIPTION
Across all rules specified on applicable Routes, precedence must be given to the match having:

“Exact” path match.
“Prefix” path match with largest number of characters.
Method match.
Largest number of header matches.
Largest number of query param matches.
Note: The precedence of RegularExpression path matches are implementation-specific.

If ties still exist across multiple Routes, matching precedence MUST be determined in order of the following criteria, continuing on ties:

The oldest Route based on creation timestamp.
The Route appearing first in alphabetical order by “{namespace}/{name}”.