### PR TITLE
fix: clean up all FSM CRDs upon uninstallation

### DIFF
--- a/charts/fsm/templates/fsm-rbac.yaml
+++ b/charts/fsm/templates/fsm-rbac.yaml
@@ -89,15 +89,15 @@ rules:
 
   # FSM's MultiCluster resource API
   - apiGroups: ["flomesh.io"]
-    resources: ["clusters", "proxyprofiles", "serviceimports", "serviceexports", "globaltrafficpolicies"]
+    resources: ["clusters", "serviceimports", "serviceexports", "globaltrafficpolicies"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
   - apiGroups: ["flomesh.io"]
-    resources: ["clusters/finalizers", "proxyprofiles/finalizers", "serviceimports/finalizers", "serviceexports/finalizers", "globaltrafficpolicies/finalizers"]
+    resources: ["clusters/finalizers", "serviceimports/finalizers", "serviceexports/finalizers", "globaltrafficpolicies/finalizers"]
     verbs: ["update"]
 
   - apiGroups: ["flomesh.io"]
-    resources: ["clusters/status", "proxyprofiles/status", "serviceimports/status", "serviceexports/status", "globaltrafficpolicies/status"]
+    resources: ["clusters/status", "serviceimports/status", "serviceexports/status", "globaltrafficpolicies/status"]
     verbs: ["get", "patch", "update"]
 
   # FSM's custom plugin API

--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -315,14 +315,14 @@ func (d *uninstallMeshCmd) uninstallCustomResourceDefinitions() error {
 		err := d.extensionsClientset.ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), crd.Name, metav1.DeleteOptions{})
 
 		if err == nil {
-			fmt.Fprintf(d.out, "Successfully deleted FSM CRD: %s\n", crd)
+			fmt.Fprintf(d.out, "Successfully deleted FSM CRD: %s\n", crd.Name)
 			continue
 		}
 
 		if k8sApiErrors.IsNotFound(err) {
-			fmt.Fprintf(d.out, "Ignoring - did not find FSM CRD: %s\n", crd)
+			fmt.Fprintf(d.out, "Ignoring - did not find FSM CRD: %s\n", crd.Name)
 		} else {
-			fmt.Fprintf(d.out, "Failed to delete FSM CRD %s: %s\n", crd, err.Error())
+			fmt.Fprintf(d.out, "Failed to delete FSM CRD %s: %s\n", crd.Name, err.Error())
 			failedDeletions = append(failedDeletions, crd.Name)
 		}
 	}

--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -287,22 +287,32 @@ func (d *uninstallMeshCmd) uninstallClusterResources() []string {
 
 // uninstallCustomResourceDefinitions uninstalls fsm and smi-related crds from the cluster.
 func (d *uninstallMeshCmd) uninstallCustomResourceDefinitions() error {
-	crds := []string{
-		"egresses.policy.flomesh.io",
-		"ingressbackends.policy.flomesh.io",
-		"meshconfigs.config.flomesh.io",
-		"meshRootCertificate.config.flomesh.io",
-		"upstreamtrafficsettings.policy.flomesh.io",
-		"retries.policy.flomesh.io",
-		"httproutegroups.specs.smi-spec.io",
-		"tcproutes.specs.smi-spec.io",
-		"trafficsplits.split.smi-spec.io",
-		"traffictargets.access.smi-spec.io",
+	//crds := []string{
+	//	"egresses.policy.flomesh.io",
+	//	"ingressbackends.policy.flomesh.io",
+	//	"meshconfigs.config.flomesh.io",
+	//	"meshRootCertificate.config.flomesh.io",
+	//	"upstreamtrafficsettings.policy.flomesh.io",
+	//	"retries.policy.flomesh.io",
+	//	"httproutegroups.specs.smi-spec.io",
+	//	"tcproutes.specs.smi-spec.io",
+	//	"trafficsplits.split.smi-spec.io",
+	//	"traffictargets.access.smi-spec.io",
+	//}
+
+	crds, err := d.extensionsClientset.ApiextensionsV1().CustomResourceDefinitions().List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set(map[string]string{
+			constants.FSMAppNameLabelKey: constants.FSMAppNameLabelValue,
+		}).String(),
+	})
+	if err != nil {
+		fmt.Fprintf(d.out, "Failed to list FSM CRDs in the cluster: %s", err.Error())
+		return errors.New(err.Error())
 	}
 
 	var failedDeletions []string
-	for _, crd := range crds {
-		err := d.extensionsClientset.ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), crd, metav1.DeleteOptions{})
+	for _, crd := range crds.Items {
+		err := d.extensionsClientset.ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), crd.Name, metav1.DeleteOptions{})
 
 		if err == nil {
 			fmt.Fprintf(d.out, "Successfully deleted FSM CRD: %s\n", crd)
@@ -313,7 +323,7 @@ func (d *uninstallMeshCmd) uninstallCustomResourceDefinitions() error {
 			fmt.Fprintf(d.out, "Ignoring - did not find FSM CRD: %s\n", crd)
 		} else {
 			fmt.Fprintf(d.out, "Failed to delete FSM CRD %s: %s\n", crd, err.Error())
-			failedDeletions = append(failedDeletions, crd)
+			failedDeletions = append(failedDeletions, crd.Name)
 		}
 	}
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?