### PR TITLE
fix: minimum k8s for fsm-ingress

### DIFF
--- a/cmd/fsm-ingress/fsm-ingress.go
+++ b/cmd/fsm-ingress/fsm-ingress.go
@@ -91,7 +91,7 @@ func main() {
 	kubeClient := kubernetes.NewForConfigOrDie(kubeconfig)
 	configClient := configClientset.NewForConfigOrDie(kubeconfig)
 
-	if !version.IsSupportedK8sVersionForGatewayAPI(kubeClient) {
+	if !version.IsSupportedK8sVersion(kubeClient) {
 		log.Error().Msgf("kubernetes server version %s is not supported, requires at least %s",
 			version.ServerVersion.String(), version.MinK8sVersionForGatewayAPI.String())
 		os.Exit(1)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?