### PR TITLE
fix: don't delete svc from cache if failed to delete svc from FLB

### DIFF
--- a/pkg/controllers/flb/event_handlers.go
+++ b/pkg/controllers/flb/event_handlers.go
@@ -40,6 +40,7 @@ func (r *serviceReconciler) onSvcUpdate(oldObj, newObj interface{}) {
 		err := retry.OnError(retry.DefaultBackoff, retriableFn, delFn)
 		if err != nil {
 			log.Error().Msgf("Failed to delete entry from FLB: %v", err)
+			return
 		}
 
 		// Remove the service from the cache if it was deleted from FLB


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?