### PR TITLE
fix: clean up LoadBalancer address if it's not FLB svc anymore

### DIFF
--- a/pkg/controllers/flb/event_handlers.go
+++ b/pkg/controllers/flb/event_handlers.go
@@ -39,6 +39,11 @@ func (r *serviceReconciler) onSvcUpdate(oldObj, newObj interface{}) {
 				return err
 			}
 
+			svc.Status.LoadBalancer.Ingress = nil
+			if err := r.fctx.Status().Update(context.Background(), svc); err != nil {
+				return err
+			}
+
 			if _, err := r.deleteEntryFromFLB(context.Background(), svc); err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?