### PR TITLE
feat: use Endpoints to calculate backend addresses if k8s version is under 1.21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,13 @@ jobs:
           - k8s_version: v1.19.16
             focus: "Test traffic from client to backend service routing by FSM Gateway"
             bucket: ".*"
+          - k8s_version: v1.20.15
+            focus: "Test traffic from client to backend service routing by FSM Gateway"
+            bucket: ".*"
           - k8s_version: v1.21.14
+            focus: "Test traffic from client to backend service routing by FSM Gateway"
+            bucket: ".*"
+          - k8s_version: v1.23.17
             focus: "Test traffic from client to backend service routing by FSM Gateway"
             bucket: ".*"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,6 +191,13 @@ jobs:
           - k8s_version: v1.27.11
             focus: "Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP"
             bucket: ".*"
+          - k8s_version: v1.19.16
+            focus: "Test traffic from client to backend service routing by FSM Gateway"
+            bucket: ".*"
+          - k8s_version: v1.21.14
+            focus: "Test traffic from client to backend service routing by FSM Gateway"
+            bucket: ".*"
+
     env:
       CTR_TAG: ${{ github.sha }}
       CTR_REGISTRY: "localhost:5000" # unused for kind, but currently required in framework

--- a/charts/fsm/README.md
+++ b/charts/fsm/README.md
@@ -123,6 +123,7 @@ The following table lists the configurable parameters of the fsm chart and their
 | fsm.featureFlags.enableValidateGatewayListenerHostname | bool | `true` | Enable validate Gateway listener hostname, enforce the hostname is DNS name not IP address |
 | fsm.featureFlags.enableValidateHTTPRouteHostnames | bool | `true` | Enable validate HTTP route hostnames, enforce the hostname is DNS name not IP address |
 | fsm.featureFlags.enableValidateTLSRouteHostnames | bool | `true` | Enable validate TLS route hostnames, enforce the hostname is DNS name not IP address |
+| fsm.featureFlags.useEndpointSlicesForGateway | bool | `true` | Use EndpointSlices for calculating Gateway routes, it's enabled by default if running on Kubernetes 1.21 or later |
 | fsm.flb.baseUrl | string | `"http://localhost:1337"` |  |
 | fsm.flb.defaultAddressPool | string | `"default"` |  |
 | fsm.flb.defaultAlgo | string | `"rr"` | Default algorithm for load balancing, default value is `"rr"`(Round Robin). Available optiosn are `"ch"`(Consistency Hash) and `"lc"`(Least Connections)  |

--- a/charts/fsm/templates/fsm-rbac.yaml
+++ b/charts/fsm/templates/fsm-rbac.yaml
@@ -35,6 +35,14 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch"]
 {{- end }}
 
+  - apiGroups: [ "policy" ]
+    resources: [ "poddisruptionbudgets" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - apiGroups: [ "autoscaling" ]
+    resources: [ "horizontalpodautoscalers" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete"]
+
   # Port forwarding is needed for the FSM pod to be able to connect
   # to participating Sidecars and fetch their configuration.
   # This is used by the FSM debugging system.

--- a/charts/fsm/templates/preset-mesh-config.yaml
+++ b/charts/fsm/templates/preset-mesh-config.yaml
@@ -94,7 +94,8 @@ data:
         "enableValidateGRPCRouteHostnames": {{.Values.fsm.featureFlags.enableValidateGRPCRouteHostnames | mustToJson}},
         "enableValidateTLSRouteHostnames": {{.Values.fsm.featureFlags.enableValidateTLSRouteHostnames | mustToJson}},
         "enableGatewayAgentService": {{.Values.fsm.featureFlags.enableGatewayAgentService | mustToJson}},
-        "enableGatewayProxyTag": {{.Values.fsm.featureFlags.enableGatewayProxyTag | mustToJson}}
+        "enableGatewayProxyTag": {{.Values.fsm.featureFlags.enableGatewayProxyTag | mustToJson}},
+        "useEndpointSlicesForGateway": {{ (and .Values.fsm.featureFlags.useEndpointSlicesForGateway (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion)) | mustToJson }}
       },
       "pluginChains": {{.Values.fsm.pluginChains | mustToJson }},
       "ingress": {

--- a/charts/fsm/values.schema.json
+++ b/charts/fsm/values.schema.json
@@ -2150,7 +2150,8 @@
                         "enableValidateGRPCRouteHostnames",
                         "enableValidateTLSRouteHostnames",
                         "enableGatewayAgentService",
-                        "enableGatewayProxyTag"
+                        "enableGatewayProxyTag",
+                        "useEndpointSlicesForGateway"
                     ],
                     "properties": {
                         "enableEgressPolicy": {
@@ -2313,6 +2314,15 @@
                           "description": "Enable proxy-tag header for gateway",
                           "examples": [
                             false
+                          ]
+                        },
+                        "useEndpointSlicesForGateway": {
+                          "$id": "#/properties/fsm/properties/featureFlags/properties/useEndpointSlicesForGateway",
+                          "type": "boolean",
+                          "title": "UseEndpointSlicesForGateway",
+                          "description": "Use EndpointSlices for calculating Gateway routes",
+                          "examples": [
+                            true
                           ]
                         }
                     },

--- a/charts/fsm/values.yaml
+++ b/charts/fsm/values.yaml
@@ -748,6 +748,8 @@ fsm:
     enableGatewayAgentService: false
     # -- Enable Gateway proxy-tag header for remote host
     enableGatewayProxyTag: false
+    # -- Use EndpointSlices for calculating Gateway routes, it's enabled by default if running on Kubernetes 1.21 or later
+    useEndpointSlicesForGateway: true
 
   # -- Node tolerations applied to control plane pods.
   # The specified tolerations allow pods to schedule onto nodes with matching taints.

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/gateway/templates/pod-disruption-budget.yaml
+++ b/charts/gateway/templates/pod-disruption-budget.yaml
@@ -1,5 +1,8 @@
 {{- if and .Values.fsm.fsmGateway.podDisruptionBudget.enabled  (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ printf "fsm-gateway-%s-pdb" .Values.gwy.metadata.namespace }}
@@ -13,4 +16,3 @@ spec:
     matchLabels:
       app: fsm-gateway
       gateway.flomesh.io/ns: {{ .Values.gwy.metadata.namespace }}
-{{- end }}

--- a/charts/gateway/templates/pod-disruption-budget.yaml
+++ b/charts/gateway/templates/pod-disruption-budget.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.fsm.fsmGateway.podDisruptionBudget.enabled  (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if and .Values.fsm.fsmGateway.podDisruptionBudget.enabled}}
+{{- if  (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1
@@ -16,3 +17,4 @@ spec:
     matchLabels:
       app: fsm-gateway
       gateway.flomesh.io/ns: {{ .Values.gwy.metadata.namespace }}
+{{- end }}

--- a/charts/gateway/templates/role.yaml
+++ b/charts/gateway/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/gateway/templates/rolebinding.yaml
+++ b/charts/gateway/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/gateway/templates/route.yaml
+++ b/charts/gateway/templates/route.yaml
@@ -1,2 +1,2 @@
-{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) }}
 {{- end }}

--- a/charts/gateway/templates/service-tcp.yaml
+++ b/charts/gateway/templates/service-tcp.yaml
@@ -1,4 +1,4 @@
-{{- if and (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) .Values.hasTCP }}
+{{- if and (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) .Values.hasTCP }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/gateway/templates/service-udp.yaml
+++ b/charts/gateway/templates/service-udp.yaml
@@ -1,4 +1,4 @@
-{{- if and (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) .Values.hasUDP }}
+{{- if and (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) .Values.hasUDP }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/gateway/templates/serviceaccount.yaml
+++ b/charts/gateway/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cmd/fsm-bootstrap/crds/config.flomesh.io_meshconfigs.yaml
+++ b/cmd/fsm-bootstrap/crds/config.flomesh.io_meshconfigs.yaml
@@ -1480,6 +1480,10 @@ spec:
                     description: EnableValidateTCPRouteHostnames defines if validate
                       tcp route hostnames is enabled.
                     type: boolean
+                  useEndpointSlicesForGateway:
+                    description: UseEndpointSlicesForGateway defines if endpoint slices
+                      are enabled for calculating gateway routes.
+                    type: boolean
                 required:
                 - enableAccessCertPolicy
                 - enableAccessControlPolicy
@@ -1498,6 +1502,7 @@ spec:
                 - enableValidateGatewayListenerHostname
                 - enableValidateHTTPRouteHostnames
                 - enableValidateTLSRouteHostnames
+                - useEndpointSlicesForGateway
                 type: object
               flb:
                 description: FLB defines the configurations of FLB features.

--- a/pkg/apis/config/v1alpha3/mesh_config.go
+++ b/pkg/apis/config/v1alpha3/mesh_config.go
@@ -400,6 +400,9 @@ type FeatureFlags struct {
 
 	// EnableGatewayProxyTag defines if gateway proxy-tag header is enabled.
 	EnableGatewayProxyTag bool `json:"enableGatewayProxyTag"`
+
+	// UseEndpointSlicesForGateway defines if endpoint slices are enabled for calculating gateway routes.
+	UseEndpointSlicesForGateway bool `json:"useEndpointSlicesForGateway"`
 }
 
 // RepoServerSpec is the type to represent repo server.

--- a/pkg/connector/ctok/endpoint.go
+++ b/pkg/connector/ctok/endpoint.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	"github.com/flomesh-io/fsm/pkg/connector"
-	"github.com/flomesh-io/fsm/pkg/constants"
 	"github.com/flomesh-io/fsm/pkg/utils"
 )
 
@@ -156,7 +155,7 @@ func (t *endpointsResource) updateGatewayEndpointSlice(ctx context.Context, endp
 	_ = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		eptSliceClient := syncer.kubeClient.DiscoveryV1().EndpointSlices(endpointsDup.Namespace)
 		labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{
-			constants.KubernetesEndpointSliceServiceNameLabel: endpointsDup.Name,
+			discoveryv1.LabelServiceName: endpointsDup.Name,
 		}}
 		listOptions := metav1.ListOptions{LabelSelector: labels.Set(labelSelector.MatchLabels).String()}
 		eptSliceList, err := eptSliceClient.List(ctx, listOptions)

--- a/pkg/controllers/gateway/v1/gateway_controller.go
+++ b/pkg/controllers/gateway/v1/gateway_controller.go
@@ -32,8 +32,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flomesh-io/fsm/pkg/version"
-
 	"sigs.k8s.io/yaml"
 
 	gwclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -767,16 +765,11 @@ func (r *gatewayReconciler) updateConfig(_ *gwv1.Gateway, _ configurator.Configu
 func (r *gatewayReconciler) deployGateway(gw *gwv1.Gateway, mc configurator.Configurator) (ctrl.Result, error) {
 	actionConfig := helm.ActionConfig(gw.Namespace, log.Debug().Msgf)
 
-	tplVer := constants.KubeVersion119
-	if version.IsEndpointSliceEnabled(r.fctx.KubeClient) {
-		tplVer = constants.KubeVersion121
-	}
-
 	templateClient := helm.TemplateClient(
 		actionConfig,
 		fmt.Sprintf("fsm-gateway-%s", gw.Namespace),
 		gw.Namespace,
-		tplVer,
+		constants.KubeVersion119,
 	)
 	if ctrlResult, err := helm.RenderChart(templateClient, gw, chartSource, mc, r.fctx.Client, r.fctx.Scheme, r.resolveValues); err != nil {
 		defer r.recorder.Eventf(gw, corev1.EventTypeWarning, "Deploy", "Failed to deploy gateway: %s", err)

--- a/pkg/controllers/gateway/v1/gateway_controller.go
+++ b/pkg/controllers/gateway/v1/gateway_controller.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flomesh-io/fsm/pkg/version"
+
 	"sigs.k8s.io/yaml"
 
 	gwclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -778,6 +780,14 @@ func (r *gatewayReconciler) deployGateway(gw *gwv1.Gateway, mc configurator.Conf
 	defer r.recorder.Eventf(gw, corev1.EventTypeNormal, "Deploy", "Deploy gateway successfully")
 
 	return ctrl.Result{}, nil
+}
+
+func (r *gatewayReconciler) kubeVersionForTemplate() *chartutil.KubeVersion {
+	if version.IsEndpointSliceEnabled(r.fctx.KubeClient) {
+		return constants.KubeVersion121
+	}
+
+	return constants.KubeVersion119
 }
 
 func (r *gatewayReconciler) resolveValues(object metav1.Object, mc configurator.Configurator) (map[string]interface{}, error) {

--- a/pkg/controllers/gateway/v1/gateway_controller.go
+++ b/pkg/controllers/gateway/v1/gateway_controller.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flomesh-io/fsm/pkg/version"
+
 	"sigs.k8s.io/yaml"
 
 	gwclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -764,11 +766,17 @@ func (r *gatewayReconciler) updateConfig(_ *gwv1.Gateway, _ configurator.Configu
 
 func (r *gatewayReconciler) deployGateway(gw *gwv1.Gateway, mc configurator.Configurator) (ctrl.Result, error) {
 	actionConfig := helm.ActionConfig(gw.Namespace, log.Debug().Msgf)
+
+	tplVer := constants.KubeVersion119
+	if version.IsEndpointSliceEnabled(r.fctx.KubeClient) {
+		tplVer = constants.KubeVersion121
+	}
+
 	templateClient := helm.TemplateClient(
 		actionConfig,
 		fmt.Sprintf("fsm-gateway-%s", gw.Namespace),
 		gw.Namespace,
-		constants.KubeVersion121,
+		tplVer,
 	)
 	if ctrlResult, err := helm.RenderChart(templateClient, gw, chartSource, mc, r.fctx.Client, r.fctx.Scheme, r.resolveValues); err != nil {
 		defer r.recorder.Eventf(gw, corev1.EventTypeWarning, "Deploy", "Failed to deploy gateway: %s", err)

--- a/pkg/controllers/gateway/v1/gateway_controller.go
+++ b/pkg/controllers/gateway/v1/gateway_controller.go
@@ -771,7 +771,7 @@ func (r *gatewayReconciler) deployGateway(gw *gwv1.Gateway, mc configurator.Conf
 		actionConfig,
 		fmt.Sprintf("fsm-gateway-%s", gw.Namespace),
 		gw.Namespace,
-		constants.KubeVersion119,
+		r.kubeVersionForTemplate(),
 	)
 	if ctrlResult, err := helm.RenderChart(templateClient, gw, chartSource, mc, r.fctx.Client, r.fctx.Scheme, r.resolveValues); err != nil {
 		defer r.recorder.Eventf(gw, corev1.EventTypeWarning, "Deploy", "Failed to deploy gateway: %s", err)

--- a/pkg/controllers/servicelb/service_controller.go
+++ b/pkg/controllers/servicelb/service_controller.go
@@ -31,6 +31,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/flomesh-io/fsm/pkg/version"
+
 	"github.com/flomesh-io/fsm/pkg/constants"
 
 	appv1 "k8s.io/api/apps/v1"
@@ -318,6 +320,13 @@ func (r *serviceReconciler) updateService(ctx context.Context, svc *corev1.Servi
 	expectedIPs, err := r.podIPs(ctx, pods.Items, svc)
 	if err != nil {
 		return err
+	}
+
+	if version.IsDualStackEnabled(r.fctx.KubeClient) {
+		expectedIPs, err = utils.FilterByIPFamily(expectedIPs, svc)
+		if err != nil {
+			return err
+		}
 	}
 
 	sort.Strings(expectedIPs)

--- a/pkg/controllers/servicelb/service_controller.go
+++ b/pkg/controllers/servicelb/service_controller.go
@@ -411,10 +411,10 @@ func (r *serviceReconciler) podIPs(ctx context.Context, pods []corev1.Pod, svc *
 		ips = keys(intIPs)
 	}
 
-	ips, err := utils.FilterByIPFamily(ips, svc)
-	if err != nil {
-		return nil, err
-	}
+	//ips, err := utils.FilterByIPFamily(ips, svc)
+	//if err != nil {
+	//	return nil, err
+	//}
 
 	//if len(ips) > 0 && h.rootless {
 	//    return []string{"127.0.0.1"}, nil

--- a/pkg/gateway/cache/endpoints_trigger.go
+++ b/pkg/gateway/cache/endpoints_trigger.go
@@ -17,13 +17,13 @@ func (p *EndpointsTrigger) Insert(obj interface{}, cache *GatewayCache) bool {
 		return false
 	}
 
-	//cache.mutex.Lock()
-	//defer cache.mutex.Unlock()
-
 	key := utils.ObjectKey(ep)
-	//cache.endpoints[key] = struct{}{}
 
-	return cache.isHeadlessServiceWithoutSelector(key) && cache.isRoutableService(key)
+	if cache.useEndpointSlices {
+		return cache.isHeadlessService(key) && cache.isRoutableService(key)
+	} else {
+		return cache.isRoutableService(key)
+	}
 }
 
 // Delete removes the Endpoints object from the cache and returns true if the cache was modified
@@ -33,15 +33,12 @@ func (p *EndpointsTrigger) Delete(obj interface{}, cache *GatewayCache) bool {
 		log.Error().Msgf("unexpected object type %T", obj)
 		return false
 	}
-	//
-	//cache.mutex.Lock()
-	//defer cache.mutex.Unlock()
-	//
-	key := utils.ObjectKey(ep)
-	//_, found := cache.endpoints[key]
-	//delete(cache.endpoints, key)
-	//
-	//return found
 
-	return cache.isHeadlessServiceWithoutSelector(key) && cache.isRoutableService(key)
+	key := utils.ObjectKey(ep)
+
+	if cache.useEndpointSlices {
+		return cache.isHeadlessService(key) && cache.isRoutableService(key)
+	} else {
+		return cache.isRoutableService(key)
+	}
 }

--- a/pkg/gateway/cache/endpointslices_trigger.go
+++ b/pkg/gateway/cache/endpointslices_trigger.go
@@ -4,8 +4,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/flomesh-io/fsm/pkg/constants"
 )
 
 // EndpointSlicesTrigger is responsible for processing EndpointSlices
@@ -23,7 +21,7 @@ func (p *EndpointSlicesTrigger) Insert(obj interface{}, cache *GatewayCache) boo
 		return false
 	}
 
-	svcName := eps.Labels[constants.KubernetesEndpointSliceServiceNameLabel]
+	svcName := eps.Labels[discoveryv1.LabelServiceName]
 	if len(svcName) == 0 {
 		return false
 	}

--- a/pkg/gateway/cache/methods.go
+++ b/pkg/gateway/cache/methods.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"github.com/flomesh-io/fsm/pkg/k8s"
 	"k8s.io/utils/ptr"
 
 	gwtypes "github.com/flomesh-io/fsm/pkg/gateway/types"
@@ -375,7 +376,7 @@ func (c *GatewayCache) isHeadlessServiceWithoutSelector(key client.ObjectKey) bo
 		return false
 	}
 
-	return service.Spec.ClusterIP == corev1.ClusterIPNone && len(service.Spec.Selector) == 0
+	return k8s.IsHeadlessService(*service)
 }
 
 func (c *GatewayCache) isRefToService(referer client.Object, ref gwv1.BackendObjectReference, service client.ObjectKey) bool {

--- a/pkg/gateway/cache/methods.go
+++ b/pkg/gateway/cache/methods.go
@@ -1,8 +1,9 @@
 package cache
 
 import (
-	"github.com/flomesh-io/fsm/pkg/k8s"
 	"k8s.io/utils/ptr"
+
+	"github.com/flomesh-io/fsm/pkg/k8s"
 
 	gwtypes "github.com/flomesh-io/fsm/pkg/gateway/types"
 	"github.com/flomesh-io/fsm/pkg/k8s/informers"

--- a/pkg/gateway/cache/methods.go
+++ b/pkg/gateway/cache/methods.go
@@ -370,7 +370,7 @@ func (c *GatewayCache) getServiceFromCache(key client.ObjectKey) (*corev1.Servic
 	return obj, nil
 }
 
-func (c *GatewayCache) isHeadlessServiceWithoutSelector(key client.ObjectKey) bool {
+func (c *GatewayCache) isHeadlessService(key client.ObjectKey) bool {
 	service, err := c.getServiceFromCache(key)
 	if err != nil {
 		log.Error().Msgf("failed to get service from cache: %v", err)

--- a/pkg/gateway/cache/processor.go
+++ b/pkg/gateway/cache/processor.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/flomesh-io/fsm/pkg/k8s"
 
-	"github.com/flomesh-io/fsm/pkg/version"
-
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/utils/ptr"
 
@@ -54,7 +52,7 @@ func NewGatewayProcessor(cache *GatewayCache, gateway *gwv1.Gateway, policies gl
 		rules:           make(map[int32]fgw.RouteRule),
 	}
 
-	if cache.cfg.GetFeatureFlags().UseEndpointSlicesForGateway && version.IsEndpointSliceEnabled(cache.kubeClient) {
+	if cache.useEndpointSlices {
 		p.upstreams = p.upstreamsByEndpointSlices
 	} else {
 		p.upstreams = p.upstreamsByEndpoints

--- a/pkg/gateway/cache/processor.go
+++ b/pkg/gateway/cache/processor.go
@@ -3,6 +3,11 @@ package cache
 import (
 	"fmt"
 
+	"github.com/flomesh-io/fsm/pkg/k8s"
+
+	"github.com/flomesh-io/fsm/pkg/version"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/utils/ptr"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -35,10 +40,11 @@ type GatewayProcessor struct {
 	validListeners  []gwtypes.Listener
 	services        map[string]serviceContext
 	rules           map[int32]fgw.RouteRule
+	upstreams       calculateEndpointsFunc
 }
 
 func NewGatewayProcessor(cache *GatewayCache, gateway *gwv1.Gateway, policies globalPolicyAttachments, referenceGrants []client.Object) *GatewayProcessor {
-	return &GatewayProcessor{
+	p := &GatewayProcessor{
 		cache:           cache,
 		gateway:         gateway,
 		policies:        policies,
@@ -47,6 +53,14 @@ func NewGatewayProcessor(cache *GatewayCache, gateway *gwv1.Gateway, policies gl
 		services:        make(map[string]serviceContext),
 		rules:           make(map[int32]fgw.RouteRule),
 	}
+
+	if cache.cfg.GetFeatureFlags().UseEndpointSlicesForGateway && version.IsEndpointSliceEnabled(cache.kubeClient) {
+		p.upstreams = p.upstreamsByEndpointSlices
+	} else {
+		p.upstreams = p.upstreamsByEndpoints
+	}
+
+	return p
 }
 
 func (c *GatewayProcessor) build() *fgw.ConfigSpec {
@@ -267,63 +281,14 @@ func (c *GatewayProcessor) serviceConfigs() map[string]fgw.ServiceConfig {
 			continue
 		}
 
-		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				constants.KubernetesEndpointSliceServiceNameLabel: svc.Name,
-			},
-		})
-		if err != nil {
-			log.Error().Msgf("Failed to convert LabelSelector to Selector: %s", err)
+		if svc.Spec.Type == corev1.ServiceTypeExternalName {
+			log.Warn().Msgf("Type of Service %s is %s, will be ignored", svcKey, corev1.ServiceTypeExternalName)
 			continue
-		}
-
-		endpointSliceList, err := c.cache.informers.GetListers().EndpointSlice.EndpointSlices(svc.Namespace).List(selector)
-		if err != nil {
-			log.Error().Msgf("Failed to list EndpointSlice of Service %s: %s", svcKey, err)
-			continue
-		}
-
-		if len(endpointSliceList) == 0 {
-			continue
-		}
-
-		svcPort, err := getServicePort(svc, svcInfo.svcPortName.Port)
-		if err != nil {
-			log.Error().Msgf("Failed to get ServicePort: %s", err)
-			continue
-		}
-
-		filteredSlices := filterEndpointSliceList(endpointSliceList, svcPort)
-		if len(filteredSlices) == 0 {
-			log.Error().Msgf("no valid endpoints found for Service %s and port %+v", svcKey, svcPort)
-			continue
-		}
-
-		endpointSet := make(map[endpointContext]struct{})
-		for _, eps := range filteredSlices {
-			for _, endpoint := range eps.Endpoints {
-				if !isEndpointReady(endpoint) {
-					continue
-				}
-				endpointPort := findPort(eps.Ports, svcPort)
-
-				for _, address := range endpoint.Addresses {
-					ep := endpointContext{address: address, port: endpointPort}
-					endpointSet[ep] = struct{}{}
-				}
-			}
 		}
 
 		svcCfg := &fgw.ServiceConfig{
 			//Filters:   svcInfo.filters,
-			Endpoints: make(map[string]fgw.Endpoint),
-		}
-
-		for ep := range endpointSet {
-			hostport := fmt.Sprintf("%s:%d", ep.address, ep.port)
-			svcCfg.Endpoints[hostport] = fgw.Endpoint{
-				Weight: 1,
-			}
+			Endpoints: c.calculateEndpoints(svc, svcInfo.svcPortName.Port),
 		}
 
 		for _, enricher := range enrichers {
@@ -334,6 +299,112 @@ func (c *GatewayProcessor) serviceConfigs() map[string]fgw.ServiceConfig {
 	}
 
 	return configs
+}
+
+func (c *GatewayProcessor) calculateEndpoints(svc *corev1.Service, port *int32) map[string]fgw.Endpoint {
+	// If the Service is headless, use the Endpoints to get the list of backends
+	if k8s.IsHeadlessService(*svc) {
+		return c.upstreamsByEndpoints(svc, port)
+	}
+
+	return c.upstreams(svc, port)
+}
+
+func (c *GatewayProcessor) upstreamsByEndpoints(svc *corev1.Service, port *int32) map[string]fgw.Endpoint {
+	eps, err := c.cache.informers.GetListers().Endpoints.Endpoints(svc.Namespace).Get(svc.Name)
+	if err != nil {
+		log.Error().Msgf("Failed to get Endpoints of Service %s: %s", svc.Name, err)
+		return nil
+	}
+
+	if len(eps.Subsets) == 0 {
+		return nil
+	}
+
+	svcPort, err := getServicePort(svc, port)
+	if err != nil {
+		log.Error().Msgf("Failed to get ServicePort: %s", err)
+		return nil
+	}
+
+	endpointSet := make(map[endpointContext]struct{})
+	for _, subset := range eps.Subsets {
+		if endpointPort := findEndpointPort(subset.Ports, svcPort); endpointPort > 0 && endpointPort <= 65535 {
+			for _, address := range subset.Addresses {
+				ep := endpointContext{address: address.IP, port: endpointPort}
+				endpointSet[ep] = struct{}{}
+			}
+		}
+	}
+
+	endpoints := make(map[string]fgw.Endpoint)
+	for ep := range endpointSet {
+		hostport := fmt.Sprintf("%s:%d", ep.address, ep.port)
+		endpoints[hostport] = fgw.Endpoint{
+			Weight: 1,
+		}
+	}
+
+	return endpoints
+}
+
+func (c *GatewayProcessor) upstreamsByEndpointSlices(svc *corev1.Service, port *int32) map[string]fgw.Endpoint {
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			discoveryv1.LabelServiceName: svc.Name,
+		},
+	})
+	if err != nil {
+		log.Error().Msgf("Failed to convert LabelSelector to Selector: %s", err)
+		return nil
+	}
+
+	endpointSliceList, err := c.cache.informers.GetListers().EndpointSlice.EndpointSlices(svc.Namespace).List(selector)
+	if err != nil {
+		log.Error().Msgf("Failed to list EndpointSlice of Service %s/%s: %s", svc.Namespace, svc.Name, err)
+		return nil
+	}
+
+	if len(endpointSliceList) == 0 {
+		return nil
+	}
+
+	svcPort, err := getServicePort(svc, port)
+	if err != nil {
+		log.Error().Msgf("Failed to get ServicePort: %s", err)
+		return nil
+	}
+
+	filteredSlices := filterEndpointSliceList(endpointSliceList, svcPort)
+	if len(filteredSlices) == 0 {
+		log.Error().Msgf("no valid endpoints found for Service %s/%s and port %v", svc.Namespace, svc.Name, svcPort)
+		return nil
+	}
+
+	endpointSet := make(map[endpointContext]struct{})
+	for _, eps := range filteredSlices {
+		for _, endpoint := range eps.Endpoints {
+			if !isEndpointReady(endpoint) {
+				continue
+			}
+			endpointPort := findEndpointSlicePort(eps.Ports, svcPort)
+
+			for _, address := range endpoint.Addresses {
+				ep := endpointContext{address: address, port: endpointPort}
+				endpointSet[ep] = struct{}{}
+			}
+		}
+	}
+
+	endpoints := make(map[string]fgw.Endpoint)
+	for ep := range endpointSet {
+		hostport := fmt.Sprintf("%s:%d", ep.address, ep.port)
+		endpoints[hostport] = fgw.Endpoint{
+			Weight: 1,
+		}
+	}
+
+	return endpoints
 }
 
 func (c *GatewayProcessor) defaults() fgw.Defaults {

--- a/pkg/gateway/cache/types.go
+++ b/pkg/gateway/cache/types.go
@@ -30,6 +30,7 @@ import (
 	"github.com/flomesh-io/fsm/pkg/gateway/fgw"
 	gwpkg "github.com/flomesh-io/fsm/pkg/gateway/types"
 	"github.com/flomesh-io/fsm/pkg/logger"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Trigger is the interface for the functionality provided by the resources
@@ -54,6 +55,8 @@ type endpointContext struct {
 	address string
 	port    int32
 }
+
+type calculateEndpointsFunc func(svc *corev1.Service, port *int32) map[string]fgw.Endpoint
 
 type globalPolicyAttachments struct {
 	rateLimits      map[gwpkg.PolicyMatchType][]gwpav1alpha1.RateLimitPolicy

--- a/pkg/gateway/cache/types.go
+++ b/pkg/gateway/cache/types.go
@@ -26,11 +26,12 @@
 package cache
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	gwpav1alpha1 "github.com/flomesh-io/fsm/pkg/apis/policyattachment/v1alpha1"
 	"github.com/flomesh-io/fsm/pkg/gateway/fgw"
 	gwpkg "github.com/flomesh-io/fsm/pkg/gateway/types"
 	"github.com/flomesh-io/fsm/pkg/logger"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // Trigger is the interface for the functionality provided by the resources

--- a/pkg/gateway/cache/utils.go
+++ b/pkg/gateway/cache/utils.go
@@ -384,10 +384,10 @@ func ignoreEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, port corev1.S
 	}
 
 	// ignore endpoint slices that don't have a matching port.
-	return findPort(endpointSlice.Ports, port) == 0
+	return findEndpointSlicePort(endpointSlice.Ports, port) == 0
 }
 
-func findPort(ports []discoveryv1.EndpointPort, svcPort corev1.ServicePort) int32 {
+func findEndpointSlicePort(ports []discoveryv1.EndpointPort, svcPort corev1.ServicePort) int32 {
 	portName := svcPort.Name
 	for _, p := range ports {
 		if p.Port == nil {
@@ -396,6 +396,25 @@ func findPort(ports []discoveryv1.EndpointPort, svcPort corev1.ServicePort) int3
 
 		if p.Name != nil && *p.Name == portName {
 			return *p.Port
+		}
+	}
+
+	return 0
+}
+
+func findEndpointPort(ports []corev1.EndpointPort, svcPort corev1.ServicePort) int32 {
+	for i, epPort := range ports {
+		if svcPort.Name == "" {
+			// port.Name is optional if there is only one port
+			return epPort.Port
+		}
+
+		if svcPort.Name == epPort.Name {
+			return epPort.Port
+		}
+
+		if i == len(ports)-1 && svcPort.TargetPort.Type == intstr.Int {
+			return svcPort.TargetPort.IntVal
 		}
 	}
 

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -9,12 +9,16 @@ import (
 
 // FilterByIPFamily filters the given list of IPs by the IPFamilyPolicy of the given service.
 func FilterByIPFamily(ips []string, svc *corev1.Service) ([]string, error) {
-	var ipFamilyPolicy corev1.IPFamilyPolicyType
+	ipFamilyPolicy := corev1.IPFamilyPolicySingleStack
 	var ipv4Addresses []string
+	var ipv6Addresses []string
 
 	for _, ip := range ips {
 		if net.IsIPv4String(ip) {
 			ipv4Addresses = append(ipv4Addresses, ip)
+		}
+		if net.IsIPv6String(ip) {
+			ipv6Addresses = append(ipv6Addresses, ip)
 		}
 	}
 
@@ -27,7 +31,31 @@ func FilterByIPFamily(ips []string, svc *corev1.Service) ([]string, error) {
 		if svc.Spec.IPFamilies[0] == corev1.IPv4Protocol {
 			return ipv4Addresses, nil
 		}
+		if svc.Spec.IPFamilies[0] == corev1.IPv6Protocol {
+			return ipv6Addresses, nil
+		}
+	case corev1.IPFamilyPolicyPreferDualStack:
+		if svc.Spec.IPFamilies[0] == corev1.IPv4Protocol {
+			ipAddresses := append(ipv4Addresses, ipv6Addresses...)
+			return ipAddresses, nil
+		}
+		if svc.Spec.IPFamilies[0] == corev1.IPv6Protocol {
+			ipAddresses := append(ipv6Addresses, ipv4Addresses...)
+			return ipAddresses, nil
+		}
+	case corev1.IPFamilyPolicyRequireDualStack:
+		if (len(ipv4Addresses) == 0) || (len(ipv6Addresses) == 0) {
+			return nil, fmt.Errorf("one or more IP families did not have addresses available for service with ipFamilyPolicy=RequireDualStack")
+		}
+		if svc.Spec.IPFamilies[0] == corev1.IPv4Protocol {
+			ipAddresses := append(ipv4Addresses, ipv6Addresses...)
+			return ipAddresses, nil
+		}
+		if svc.Spec.IPFamilies[0] == corev1.IPv6Protocol {
+			ipAddresses := append(ipv6Addresses, ipv4Addresses...)
+			return ipAddresses, nil
+		}
 	}
 
-	return nil, fmt.Errorf("unhandled ipFamilyPolicy")
+	return nil, fmt.Errorf("unhandled ipFamilyPolicy: %s", ipFamilyPolicy)
 }

--- a/pkg/version/utils.go
+++ b/pkg/version/utils.go
@@ -17,7 +17,14 @@ var (
 	MinK8sVersion = semver.Version{Major: 1, Minor: 19, Patch: 0}
 
 	// MinEndpointSliceVersion is the minimum version of Kubernetes that supports EndpointSlice.
+	// stable since Kubernetes v1.21
+	// https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/
 	MinEndpointSliceVersion = semver.Version{Major: 1, Minor: 21, Patch: 0}
+
+	// MinDualStackSliceVersion is the minimum version of Kubernetes that supports IPv4/IPv6 dual-stack.
+	// IPv4/IPv6 dual-stack networking is enabled by default for your Kubernetes cluster starting in 1.21
+	// https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+	MinDualStackSliceVersion = semver.Version{Major: 1, Minor: 21, Patch: 0}
 
 	// MinK8sVersionForGatewayAPI is the minimum version of Kubernetes that supports Gateway API.
 	MinK8sVersionForGatewayAPI = MinK8sVersion
@@ -60,6 +67,12 @@ func IsSupportedK8sVersion(kubeClient kubernetes.Interface) bool {
 func IsEndpointSliceEnabled(kubeClient kubernetes.Interface) bool {
 	detectServerVersion(kubeClient)
 	return ServerVersion.GTE(MinEndpointSliceVersion)
+}
+
+// IsDualStackEnabled returns true if IPv4/IPv6 dual-stack is enabled in the Kubernetes cluster.
+func IsDualStackEnabled(kubeClient kubernetes.Interface) bool {
+	detectServerVersion(kubeClient)
+	return ServerVersion.GTE(MinDualStackSliceVersion)
 }
 
 // IsSupportedK8sVersionForGatewayAPI returns true if the Kubernetes cluster version is supported by the operator.

--- a/pkg/version/utils.go
+++ b/pkg/version/utils.go
@@ -20,7 +20,7 @@ var (
 	MinEndpointSliceVersion = semver.Version{Major: 1, Minor: 21, Patch: 0}
 
 	// MinK8sVersionForGatewayAPI is the minimum version of Kubernetes that supports Gateway API.
-	MinK8sVersionForGatewayAPI = MinEndpointSliceVersion
+	MinK8sVersionForGatewayAPI = MinK8sVersion
 )
 
 func getServerVersion(kubeClient kubernetes.Interface) (semver.Version, error) {

--- a/pkg/version/utils.go
+++ b/pkg/version/utils.go
@@ -64,5 +64,5 @@ func IsEndpointSliceEnabled(kubeClient kubernetes.Interface) bool {
 
 // IsSupportedK8sVersionForGatewayAPI returns true if the Kubernetes cluster version is supported by the operator.
 func IsSupportedK8sVersionForGatewayAPI(kubeClient kubernetes.Interface) bool {
-	return IsEndpointSliceEnabled(kubeClient)
+	return IsSupportedK8sVersion(kubeClient)
 }

--- a/tests/e2e/e2e_gatewayapi_test.go
+++ b/tests/e2e/e2e_gatewayapi_test.go
@@ -42,7 +42,7 @@ var _ = FSMDescribe("Test traffic among FSM Gateway",
 		OS:     OSCrossPlatform,
 	},
 	func() {
-		Context("FSMGateway", func() {
+		Context("Test traffic from client to backend service routing by FSM Gateway", func() {
 			It("allow traffic of multiple protocols through Gateway", func() {
 				// Install FSM
 				installOpts := Td.GetFSMInstallOpts()

--- a/tests/e2e/e2e_gatewayapi_test.go
+++ b/tests/e2e/e2e_gatewayapi_test.go
@@ -230,9 +230,13 @@ fsm:
 					TLS: &gwv1.GatewayTLSConfig{
 						CertificateRefs: []gwv1.SecretObjectReference{
 							{
-								Name: "https-cert",
+								Group: ptr.To(gwv1.Group(corev1.GroupName)),
+								Kind:  ptr.To(gwv1.Kind("Secret")),
+								Name:  "https-cert",
 							},
 							{
+								Group:     ptr.To(gwv1.Group(corev1.GroupName)),
+								Kind:      ptr.To(gwv1.Kind("Secret")),
 								Namespace: namespacePtr(nsGRPCSvc),
 								Name:      "grpc-cert",
 							},
@@ -263,9 +267,13 @@ fsm:
 						Mode: tlsModePtr(gwv1.TLSModeTerminate),
 						CertificateRefs: []gwv1.SecretObjectReference{
 							{
-								Name: "https-cert",
+								Group: ptr.To(gwv1.Group(corev1.GroupName)),
+								Kind:  ptr.To(gwv1.Kind("Secret")),
+								Name:  "https-cert",
 							},
 							{
+								Group:     ptr.To(gwv1.Group(corev1.GroupName)),
+								Kind:      ptr.To(gwv1.Kind("Secret")),
 								Namespace: namespacePtr(nsGRPCSvc),
 								Name:      "grpc-cert",
 							},


### PR DESCRIPTION
…under 1.21

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?