### PR TITLE
feat: validate Gateway resources by code in case CustomResourceValidationExpressions is not supported

### DIFF
--- a/pkg/apis/gateway/v1/util/validation/gatewayclass.go
+++ b/pkg/apis/gateway/v1/util/validation/gatewayclass.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"regexp"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var controllerNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`)
+
+// IsControllerNameValid checks that the provided controllerName complies with the expected
+// format. It must be a non-empty domain prefixed path.
+func IsControllerNameValid(controllerName gatewayv1.GatewayController) bool {
+	if controllerName == "" {
+		return false
+	}
+	return controllerNameRegex.Match([]byte(controllerName))
+}

--- a/pkg/apis/gateway/v1/util/validation/gatewayclass_test.go
+++ b/pkg/apis/gateway/v1/util/validation/gatewayclass_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation_test
+
+import (
+	"testing"
+
+	validationtutils "github.com/flomesh-io/fsm/pkg/apis/gateway/v1beta1/util/validation"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestIsControllerNameValid(t *testing.T) {
+	testCases := []struct {
+		name           string
+		controllerName gatewayv1.GatewayController
+		isvalid        bool
+	}{
+		{
+			name:           "empty controller name",
+			controllerName: "",
+			isvalid:        false,
+		},
+		{
+			name:           "invalid controller name 1",
+			controllerName: "example.com",
+			isvalid:        false,
+		},
+		{
+			name:           "invalid controller name 2",
+			controllerName: "example*com/bar",
+			isvalid:        false,
+		},
+		{
+			name:           "invalid controller name 3",
+			controllerName: "example/@bar",
+			isvalid:        false,
+		},
+		{
+			name:           "valid controller name",
+			controllerName: "example.com/bar",
+			isvalid:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			isValid := validationtutils.IsControllerNameValid(tc.controllerName)
+			if isValid != tc.isvalid {
+				t.Errorf("Expected validity %t, got %t", tc.isvalid, isValid)
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1/validation/common.go
+++ b/pkg/apis/gateway/v1/validation/common.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// ValidateParentRefs validates ParentRefs SectionName must be set and unique
+// when ParentRefs includes 2 or more references to the same parent
+func ValidateParentRefs(parentRefs []gatewayv1.ParentReference, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if len(parentRefs) <= 1 {
+		return nil
+	}
+	type sameKindParentRefs struct {
+		name      gatewayv1.ObjectName
+		namespace gatewayv1.Namespace
+		kind      gatewayv1.Kind
+	}
+	type parentQualifier struct {
+		section gatewayv1.SectionName
+		port    gatewayv1.PortNumber
+	}
+	parentRefsSectionMap := make(map[sameKindParentRefs]sets.Set[parentQualifier])
+	for i, p := range parentRefs {
+		targetParentRefs := sameKindParentRefs{name: p.Name, namespace: gatewayv1.Namespace(""), kind: gatewayv1.Kind("")}
+		pq := parentQualifier{}
+		if p.Namespace != nil {
+			targetParentRefs.namespace = *p.Namespace
+		}
+		if p.Kind != nil {
+			targetParentRefs.kind = *p.Kind
+		}
+		if p.SectionName != nil {
+			pq.section = *p.SectionName
+		}
+		if p.Port != nil {
+			pq.port = *p.Port
+		}
+		if s, ok := parentRefsSectionMap[targetParentRefs]; ok {
+			if s.UnsortedList()[0] == (parentQualifier{}) || pq == (parentQualifier{}) {
+				errs = append(errs, field.Required(path.Child("parentRefs"), "sectionNames or ports must be specified when more than one parentRef refers to the same parent"))
+				return errs
+			}
+			if s.Has(pq) {
+				fieldPath := path.Index(i).Child("parentRefs")
+				var val any
+				if len(pq.section) > 0 {
+					fieldPath = fieldPath.Child("sectionName")
+					val = pq.section
+				} else {
+					fieldPath = fieldPath.Child("port")
+					val = pq.port
+				}
+				errs = append(errs, field.Invalid(fieldPath, val, "must be unique when ParentRefs includes 2 or more references to the same parent"))
+				return errs
+			}
+			parentRefsSectionMap[targetParentRefs].Insert(pq)
+		} else {
+			parentRefsSectionMap[targetParentRefs] = sets.New(pq)
+		}
+	}
+	return errs
+}
+
+func ptrTo[T any](a T) *T {
+	return &a
+}
+
+// validateParentRefs validates ParentRefs SectionName must be set and unique
+// when ParentRefs includes 2 or more references to the same parent
+var validateParentRefs = ValidateParentRefs

--- a/pkg/apis/gateway/v1/validation/common.go
+++ b/pkg/apis/gateway/v1/validation/common.go
@@ -80,6 +80,7 @@ func ValidateParentRefs(parentRefs []gatewayv1.ParentReference, path *field.Path
 	return errs
 }
 
+//lint:ignore U1000 ignore unused
 func ptrTo[T any](a T) *T {
 	return &a
 }

--- a/pkg/apis/gateway/v1/validation/common_test.go
+++ b/pkg/apis/gateway/v1/validation/common_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var path = field.Path{}
+
+func TestValidateParentRefs(t *testing.T) {
+	namespace := gatewayv1.Namespace("example-namespace")
+	kind := gatewayv1.Kind("Gateway")
+	sectionA := gatewayv1.SectionName("Section A")
+	sectionB := gatewayv1.SectionName("Section B")
+	sectionC := gatewayv1.SectionName("Section C")
+
+	tests := []struct {
+		name       string
+		parentRefs []gatewayv1.ParentReference
+		err        string
+	}{{
+		name: "valid ParentRefs includes 1 reference",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+		},
+		err: "",
+	}, {
+		name: "valid ParentRefs includes 2 references",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionB,
+			},
+		},
+		err: "",
+	}, {
+		name: "valid ParentRefs when different references have the same section name",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:        "example A",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example B",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+		},
+		err: "",
+	}, {
+		name: "valid ParentRefs includes more references to the same parent",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionB,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionC,
+			},
+		},
+		err: "",
+	}, {
+		name: "invalid ParentRefs due to the same section names to the same parentRefs",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+		},
+		err: "must be unique when ParentRefs",
+	}, {
+		name: "invalid ParentRefs due to section names not set to the same ParentRefs",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name: "example",
+			},
+			{
+				Name: "example",
+			},
+		},
+		err: "sectionNames or ports must be specified",
+	}, {
+		name: "invalid ParentRefs due to more same section names to the same ParentRefs",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: nil,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionB,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+		},
+		err: "sectionNames or ports must be specified",
+	}, {
+		name: "invalid ParentRefs when one ParentRef section name not set to the same ParentRefs",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: nil,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+		},
+		err: "sectionNames or ports must be specified",
+	}, {
+		name: "invalid ParentRefs when next ParentRef section name not set to the same ParentRefs",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: nil,
+			},
+		},
+		err: "sectionNames or ports must be specified",
+	}, {
+		name: "valid ParentRefs with multiple port references to the same parent",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1.PortNumber(80)),
+			},
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1.PortNumber(81)),
+			},
+		},
+		err: "",
+	}, {
+		name: "valid ParentRefs with multiple mixed references to the same parent",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1.PortNumber(80)),
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+		},
+		err: "",
+	}, {
+		name: "invalid ParentRefs due to same port references to the same parent",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1.PortNumber(80)),
+			},
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1.PortNumber(80)),
+			},
+		},
+		err: "port: Invalid value: 80: must be unique when ParentRefs",
+	}, {
+		name: "invalid ParentRefs due to mixed port references to the same parent",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1.PortNumber(80)),
+			},
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      nil,
+			},
+		},
+		err: "Required value: sectionNames or ports must be specified",
+	}, {
+		name: "valid ParentRefs with multiple same port references to different section of a  parent",
+		parentRefs: []gatewayv1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Port:        ptrTo(gatewayv1.PortNumber(80)),
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Port:        ptrTo(gatewayv1.PortNumber(80)),
+				SectionName: &sectionB,
+			},
+		},
+		err: "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := gatewayv1.CommonRouteSpec{
+				ParentRefs: tc.parentRefs,
+			}
+			errs := ValidateParentRefs(spec.ParentRefs, path.Child("spec"))
+			if tc.err == "" {
+				if len(errs) != 0 {
+					t.Errorf("got %d errors, want none: %s", len(errs), errs)
+				}
+			} else {
+				if errs == nil {
+					t.Errorf("got no errors, want %q", tc.err)
+				} else if !strings.Contains(errs.ToAggregate().Error(), tc.err) {
+					t.Errorf("got %d errors, want %q: %s", len(errs), tc.err, errs)
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1/validation/doc.go
+++ b/pkg/apis/gateway/v1/validation/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package validation has functions for validating the correctness of api
+// objects and explaining what's wrong with them when they're not valid.
+package validation // import "github.com/flomesh-io/fsm/pkg/apis/gateway/v1/validation"

--- a/pkg/apis/gateway/v1/validation/gateway.go
+++ b/pkg/apis/gateway/v1/validation/gateway.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"net/netip"
+	"regexp"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var (
+	// set of protocols for which we need to validate that hostname is empty
+	protocolsHostnameInvalid = map[gatewayv1.ProtocolType]struct{}{
+		gatewayv1.TCPProtocolType: {},
+		gatewayv1.UDPProtocolType: {},
+	}
+	// set of protocols for which TLSConfig shall not be present
+	protocolsTLSInvalid = map[gatewayv1.ProtocolType]struct{}{
+		gatewayv1.HTTPProtocolType: {},
+		gatewayv1.UDPProtocolType:  {},
+		gatewayv1.TCPProtocolType:  {},
+	}
+	// set of protocols for which TLSConfig must be set
+	protocolsTLSRequired = map[gatewayv1.ProtocolType]struct{}{
+		gatewayv1.HTTPSProtocolType: {},
+		gatewayv1.TLSProtocolType:   {},
+	}
+
+	validHostnameAddress = `^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	validHostnameRegexp  = regexp.MustCompile(validHostnameAddress)
+)
+
+// ValidateGateway validates gw according to the Gateway API specification.
+// For additional details of the Gateway spec, refer to:
+//
+//	https://gateway-api.sigs.k8s.io/v1beta1/references/spec/#gateway.networking.k8s.io/v1beta1.Gateway
+//
+// Validation that is not possible with CRD annotations may be added here in the future.
+// See https://github.com/kubernetes-sigs/gateway-api/issues/868 for more information.
+func ValidateGateway(gw *gatewayv1.Gateway) field.ErrorList {
+	return ValidateGatewaySpec(&gw.Spec, field.NewPath("spec"))
+}
+
+// ValidateGatewaySpec validates whether required fields of spec are set according to the
+// Gateway API specification.
+func ValidateGatewaySpec(spec *gatewayv1.GatewaySpec, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	errs = append(errs, validateGatewayListeners(spec.Listeners, path.Child("listeners"))...)
+	errs = append(errs, validateGatewayAddresses(spec.Addresses, path.Child("addresses"))...)
+	return errs
+}
+
+// validateGatewayListeners validates whether required fields of listeners are set according
+// to the Gateway API specification.
+func validateGatewayListeners(listeners []gatewayv1.Listener, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	errs = append(errs, ValidateListenerTLSConfig(listeners, path)...)
+	errs = append(errs, validateListenerHostname(listeners, path)...)
+	errs = append(errs, ValidateTLSCertificateRefs(listeners, path)...)
+	errs = append(errs, ValidateListenerNames(listeners, path)...)
+	errs = append(errs, validateHostnameProtocolPort(listeners, path)...)
+	return errs
+}
+
+// ValidateListenerTLSConfig validates TLS config must be set when protocol is HTTPS or TLS,
+// and TLS config shall not be present when protocol is HTTP, TCP or UDP
+func ValidateListenerTLSConfig(listeners []gatewayv1.Listener, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, l := range listeners {
+		if isProtocolInSubset(l.Protocol, protocolsTLSRequired) && l.TLS == nil {
+			errs = append(errs, field.Forbidden(path.Index(i).Child("tls"), fmt.Sprintf("must be set for protocol %v", l.Protocol)))
+		}
+		if isProtocolInSubset(l.Protocol, protocolsTLSInvalid) && l.TLS != nil {
+			errs = append(errs, field.Forbidden(path.Index(i).Child("tls"), fmt.Sprintf("should be empty for protocol %v", l.Protocol)))
+		}
+	}
+	return errs
+}
+
+func isProtocolInSubset(protocol gatewayv1.ProtocolType, set map[gatewayv1.ProtocolType]struct{}) bool {
+	_, ok := set[protocol]
+	return ok
+}
+
+// validateListenerHostname validates each listener hostname
+// should be empty in case protocol is TCP or UDP
+func validateListenerHostname(listeners []gatewayv1.Listener, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, h := range listeners {
+		if isProtocolInSubset(h.Protocol, protocolsHostnameInvalid) && h.Hostname != nil {
+			errs = append(errs, field.Forbidden(path.Index(i).Child("hostname"), fmt.Sprintf("should be empty for protocol %v", h.Protocol)))
+		}
+	}
+	return errs
+}
+
+// ValidateTLSCertificateRefs validates the certificateRefs
+// must be set and not empty when tls config is set and
+// TLSModeType is terminate
+func ValidateTLSCertificateRefs(listeners []gatewayv1.Listener, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, c := range listeners {
+		if isProtocolInSubset(c.Protocol, protocolsTLSRequired) && c.TLS != nil {
+			if *c.TLS.Mode == gatewayv1.TLSModeTerminate && len(c.TLS.CertificateRefs) == 0 {
+				errs = append(errs, field.Forbidden(path.Index(i).Child("tls").Child("certificateRefs"), "should be set and not empty when TLSModeType is Terminate"))
+			}
+		}
+	}
+	return errs
+}
+
+// ValidateListenerNames validates the names of the listeners
+// must be unique within the Gateway
+func ValidateListenerNames(listeners []gatewayv1.Listener, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	nameMap := make(map[gatewayv1.SectionName]struct{}, len(listeners))
+	for i, c := range listeners {
+		if _, found := nameMap[c.Name]; found {
+			errs = append(errs, field.Duplicate(path.Index(i).Child("name"), "must be unique within the Gateway"))
+		}
+		nameMap[c.Name] = struct{}{}
+	}
+	return errs
+}
+
+// validateHostnameProtocolPort validates that the combination of port, protocol, and hostname are
+// unique for each listener.
+func validateHostnameProtocolPort(listeners []gatewayv1.Listener, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	hostnameProtocolPortSets := sets.Set[string]{}
+	for i, listener := range listeners {
+		hostname := new(gatewayv1.Hostname)
+		if listener.Hostname != nil {
+			hostname = listener.Hostname
+		}
+		protocol := listener.Protocol
+		port := listener.Port
+		hostnameProtocolPort := fmt.Sprintf("%s:%s:%d", *hostname, protocol, port)
+		if hostnameProtocolPortSets.Has(hostnameProtocolPort) {
+			errs = append(errs, field.Duplicate(path.Index(i), "combination of port, protocol, and hostname must be unique for each listener"))
+		} else {
+			hostnameProtocolPortSets.Insert(hostnameProtocolPort)
+		}
+	}
+	return errs
+}
+
+// validateGatewayAddresses validates whether fields of addresses are set according
+// to the Gateway API specification.
+func validateGatewayAddresses(addresses []gatewayv1.GatewayAddress, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	ipAddrSet, hostnameAddrSet := sets.Set[string]{}, sets.Set[string]{}
+	for i, address := range addresses {
+		if address.Type != nil {
+			if *address.Type == gatewayv1.IPAddressType {
+				if _, err := netip.ParseAddr(address.Value); err != nil {
+					errs = append(errs, field.Invalid(path.Index(i), address.Value, "invalid ip address"))
+				}
+				if ipAddrSet.Has(address.Value) {
+					errs = append(errs, field.Duplicate(path.Index(i), address.Value))
+				} else {
+					ipAddrSet.Insert(address.Value)
+				}
+			} else if *address.Type == gatewayv1.HostnameAddressType {
+				if !validHostnameRegexp.MatchString(address.Value) {
+					errs = append(errs, field.Invalid(path.Index(i), address.Value, fmt.Sprintf("must only contain valid characters (matching %s)", validHostnameAddress)))
+				}
+				if hostnameAddrSet.Has(address.Value) {
+					errs = append(errs, field.Duplicate(path.Index(i), address.Value))
+				} else {
+					hostnameAddrSet.Insert(address.Value)
+				}
+			}
+		}
+	}
+	return errs
+}

--- a/pkg/apis/gateway/v1/validation/gateway_test.go
+++ b/pkg/apis/gateway/v1/validation/gateway_test.go
@@ -1,0 +1,444 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestValidateGateway(t *testing.T) {
+	listeners := []gatewayv1.Listener{
+		{
+			Hostname: nil,
+		},
+	}
+	addresses := []gatewayv1.GatewayAddress{
+		{
+			Type: nil,
+		},
+	}
+	baseGateway := gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "foo",
+			Listeners:        listeners,
+			Addresses:        addresses,
+		},
+	}
+	tlsConfig := gatewayv1.GatewayTLSConfig{}
+
+	testCases := map[string]struct {
+		mutate     func(gw *gatewayv1.Gateway)
+		expectErrs []field.Error
+	}{
+		"tls config present with http protocol": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1.HTTPProtocolType
+				gw.Spec.Listeners[0].TLS = &tlsConfig
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls",
+					Detail:   "should be empty for protocol HTTP",
+					BadValue: "",
+				},
+			},
+		},
+		"tls config present with tcp protocol": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1.TCPProtocolType
+				gw.Spec.Listeners[0].TLS = &tlsConfig
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls",
+					Detail:   "should be empty for protocol TCP",
+					BadValue: "",
+				},
+			},
+		},
+		"tls config not set with https protocol": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1.HTTPSProtocolType
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls",
+					Detail:   "must be set for protocol HTTPS",
+					BadValue: "",
+				},
+			},
+		},
+		"tls config not set with tls protocol": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1.TLSProtocolType
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls",
+					Detail:   "must be set for protocol TLS",
+					BadValue: "",
+				},
+			},
+		},
+		"tls config not set with http protocol": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1.HTTPProtocolType
+			},
+			expectErrs: nil,
+		},
+		"tls config not set with tcp protocol": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1.TCPProtocolType
+			},
+			expectErrs: nil,
+		},
+		"tls config not set with udp protocol": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1.UDPProtocolType
+			},
+			expectErrs: nil,
+		},
+		"hostname present with tcp protocol": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostname := gatewayv1.Hostname("foo.bar.com")
+				gw.Spec.Listeners[0].Hostname = &hostname
+				gw.Spec.Listeners[0].Protocol = gatewayv1.TCPProtocolType
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].hostname",
+					Detail:   "should be empty for protocol TCP",
+					BadValue: "",
+				},
+			},
+		},
+		"hostname present with udp protocol": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostname := gatewayv1.Hostname("foo.bar.com")
+				gw.Spec.Listeners[0].Hostname = &hostname
+				gw.Spec.Listeners[0].Protocol = gatewayv1.UDPProtocolType
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].hostname",
+					Detail:   "should be empty for protocol UDP",
+					BadValue: "",
+				},
+			},
+		},
+		"certificatedRefs not set with https protocol and TLS terminate mode": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostname := gatewayv1.Hostname("foo.bar.com")
+				tlsMode := gatewayv1.TLSModeType("Terminate")
+				gw.Spec.Listeners[0].Protocol = gatewayv1.HTTPSProtocolType
+				gw.Spec.Listeners[0].Hostname = &hostname
+				gw.Spec.Listeners[0].TLS = &tlsConfig
+				gw.Spec.Listeners[0].TLS.Mode = &tlsMode
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls.certificateRefs",
+					Detail:   "should be set and not empty when TLSModeType is Terminate",
+					BadValue: "",
+				},
+			},
+		},
+		"certificatedRefs not set with tls protocol and TLS terminate mode": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostname := gatewayv1.Hostname("foo.bar.com")
+				tlsMode := gatewayv1.TLSModeType("Terminate")
+				gw.Spec.Listeners[0].Protocol = gatewayv1.TLSProtocolType
+				gw.Spec.Listeners[0].Hostname = &hostname
+				gw.Spec.Listeners[0].TLS = &tlsConfig
+				gw.Spec.Listeners[0].TLS.Mode = &tlsMode
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls.certificateRefs",
+					Detail:   "should be set and not empty when TLSModeType is Terminate",
+					BadValue: "",
+				},
+			},
+		},
+		"names are not unique within the Gateway": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostnameFoo := gatewayv1.Hostname("foo.com")
+				hostnameBar := gatewayv1.Hostname("bar.com")
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1.Listener{
+						Name:     "foo",
+						Hostname: &hostnameBar,
+					},
+				)
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.listeners[1].name",
+					BadValue: "must be unique within the Gateway",
+				},
+			},
+		},
+		"combination of port, protocol, and hostname are not unique for each listener": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostnameFoo := gatewayv1.Hostname("foo.com")
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
+				gw.Spec.Listeners[0].Protocol = gatewayv1.HTTPProtocolType
+				gw.Spec.Listeners[0].Port = 80
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1.Listener{
+						Name:     "bar",
+						Hostname: &hostnameFoo,
+						Protocol: gatewayv1.HTTPProtocolType,
+						Port:     80,
+					},
+				)
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.listeners[1]",
+					BadValue: "combination of port, protocol, and hostname must be unique for each listener",
+				},
+			},
+		},
+		"combination of port and protocol are not unique for each listener when hostnames not set": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Protocol = gatewayv1.HTTPProtocolType
+				gw.Spec.Listeners[0].Port = 80
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1.Listener{
+						Name:     "bar",
+						Protocol: gatewayv1.HTTPProtocolType,
+						Port:     80,
+					},
+				)
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.listeners[1]",
+					BadValue: "combination of port, protocol, and hostname must be unique for each listener",
+				},
+			},
+		},
+		"port is unique when protocol and hostname are the same": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostnameFoo := gatewayv1.Hostname("foo.com")
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
+				gw.Spec.Listeners[0].Protocol = gatewayv1.HTTPProtocolType
+				gw.Spec.Listeners[0].Port = 80
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1.Listener{
+						Name:     "bar",
+						Hostname: &hostnameFoo,
+						Protocol: gatewayv1.HTTPProtocolType,
+						Port:     8080,
+					},
+				)
+			},
+			expectErrs: nil,
+		},
+		"hostname is unique when protocol and port are the same": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostnameFoo := gatewayv1.Hostname("foo.com")
+				hostnameBar := gatewayv1.Hostname("bar.com")
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
+				gw.Spec.Listeners[0].Protocol = gatewayv1.HTTPProtocolType
+				gw.Spec.Listeners[0].Port = 80
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1.Listener{
+						Name:     "bar",
+						Hostname: &hostnameBar,
+						Protocol: gatewayv1.HTTPProtocolType,
+						Port:     80,
+					},
+				)
+			},
+			expectErrs: nil,
+		},
+		"protocol is unique when port and hostname are the same": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostnameFoo := gatewayv1.Hostname("foo.com")
+				tlsConfigFoo := tlsConfig
+				tlsModeFoo := gatewayv1.TLSModeType("Terminate")
+				tlsConfigFoo.Mode = &tlsModeFoo
+				tlsConfigFoo.CertificateRefs = []gatewayv1.SecretObjectReference{
+					{
+						Name: "FooCertificateRefs",
+					},
+				}
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
+				gw.Spec.Listeners[0].Protocol = gatewayv1.HTTPSProtocolType
+				gw.Spec.Listeners[0].Port = 8000
+				gw.Spec.Listeners[0].TLS = &tlsConfigFoo
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1.Listener{
+						Name:     "bar",
+						Hostname: &hostnameFoo,
+						Protocol: gatewayv1.TLSProtocolType,
+						Port:     8000,
+						TLS:      &tlsConfigFoo,
+					},
+				)
+			},
+			expectErrs: nil,
+		},
+		"ip address and hostname in addresses are valid": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1.GatewayAddress{
+					{
+						Type:  ptrTo(gatewayv1.IPAddressType),
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  ptrTo(gatewayv1.IPAddressType),
+						Value: "1111:2222:3333:4444::",
+					},
+					{
+						Type:  ptrTo(gatewayv1.HostnameAddressType),
+						Value: "foo.bar",
+					},
+				}
+			},
+			expectErrs: nil,
+		},
+		"ip address and hostname in addresses are invalid": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1.GatewayAddress{
+					{
+						Type:  ptrTo(gatewayv1.IPAddressType),
+						Value: "1.2.3.4:8080",
+					},
+					{
+						Type:  ptrTo(gatewayv1.HostnameAddressType),
+						Value: "*foo/bar",
+					},
+					{
+						Type:  ptrTo(gatewayv1.HostnameAddressType),
+						Value: "12:34:56::",
+					},
+				}
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.addresses[0]",
+					Detail:   "invalid ip address",
+					BadValue: "1.2.3.4:8080",
+				},
+				{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.addresses[1]",
+					Detail:   fmt.Sprintf("must only contain valid characters (matching %s)", validHostnameAddress),
+					BadValue: "*foo/bar",
+				},
+				{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.addresses[2]",
+					Detail:   fmt.Sprintf("must only contain valid characters (matching %s)", validHostnameAddress),
+					BadValue: "12:34:56::",
+				},
+			},
+		},
+		"duplicate ip address or hostname": {
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1.GatewayAddress{
+					{
+						Type:  ptrTo(gatewayv1.IPAddressType),
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  ptrTo(gatewayv1.IPAddressType),
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  ptrTo(gatewayv1.HostnameAddressType),
+						Value: "foo.bar",
+					},
+					{
+						Type:  ptrTo(gatewayv1.HostnameAddressType),
+						Value: "foo.bar",
+					},
+				}
+			},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.addresses[1]",
+					BadValue: "1.2.3.4",
+				},
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.addresses[3]",
+					BadValue: "foo.bar",
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			gw := baseGateway.DeepCopy()
+			tc.mutate(gw)
+			errs := ValidateGateway(gw)
+			if len(tc.expectErrs) != len(errs) {
+				t.Fatalf("Expected %d errors, got %d errors: %v", len(tc.expectErrs), len(errs), errs)
+			}
+			for i, err := range errs {
+				if err.Type != tc.expectErrs[i].Type {
+					t.Errorf("Expected error on type: %s, got: %s", tc.expectErrs[i].Type, err.Type)
+				}
+				if err.Field != tc.expectErrs[i].Field {
+					t.Errorf("Expected error on field: %s, got: %s", tc.expectErrs[i].Field, err.Field)
+				}
+				if err.Detail != tc.expectErrs[i].Detail {
+					t.Errorf("Expected error on detail: %s, got: %s", tc.expectErrs[i].Detail, err.Detail)
+				}
+				if err.BadValue != tc.expectErrs[i].BadValue {
+					t.Errorf("Expected error on bad value: %s, got: %s", tc.expectErrs[i].BadValue, err.BadValue)
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1/validation/gatewayclass.go
+++ b/pkg/apis/gateway/v1/validation/gatewayclass.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// ValidateGatewayClassUpdate validates an update to oldClass according to the
+// Gateway API specification. For additional details of the GatewayClass spec, refer to:
+// https://gateway-api.sigs.k8s.io/v1beta1/references/spec/#gateway.networking.k8s.io/v1beta1.GatewayClass
+func ValidateGatewayClassUpdate(oldClass, newClass *gatewayv1.GatewayClass) field.ErrorList {
+	if oldClass == nil || newClass == nil {
+		return nil
+	}
+	var errs field.ErrorList
+	if oldClass.Spec.ControllerName != newClass.Spec.ControllerName {
+		errs = append(errs, field.Invalid(field.NewPath("spec.controllerName"), newClass.Spec.ControllerName,
+			"cannot update an immutable field"))
+	}
+	return errs
+}

--- a/pkg/apis/gateway/v1/validation/gatewayclass_test.go
+++ b/pkg/apis/gateway/v1/validation/gatewayclass_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestValidateGatewayClassUpdate(t *testing.T) {
+	type args struct {
+		oldClass *gatewayv1.GatewayClass
+		newClass *gatewayv1.GatewayClass
+	}
+	tests := []struct {
+		name string
+		args args
+		want field.ErrorList
+	}{
+		{
+			name: "changing parameters reference is allowed",
+			args: args{
+				oldClass: &gatewayv1.GatewayClass{
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: "foo",
+					},
+				},
+				newClass: &gatewayv1.GatewayClass{
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: "foo",
+						ParametersRef: &gatewayv1.ParametersReference{
+							Group: "example.com",
+							Kind:  "GatewayClassConfig",
+							Name:  "foo",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "changing controller field results in an error",
+			args: args{
+				oldClass: &gatewayv1.GatewayClass{
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: "example.com/gateway",
+					},
+				},
+				newClass: &gatewayv1.GatewayClass{
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: "example.org/gateway",
+					},
+				},
+			},
+			want: field.ErrorList{
+				{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.controllerName",
+					Detail:   "cannot update an immutable field",
+					BadValue: gatewayv1.GatewayController("example.org/gateway"),
+				},
+			},
+		},
+		{
+			name: "nil input result in no errors",
+			args: args{
+				oldClass: nil,
+				newClass: nil,
+			},
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidateGatewayClassUpdate(tc.args.oldClass, tc.args.newClass); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ValidateGatewayClassUpdate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1/validation/grpcroute.go
+++ b/pkg/apis/gateway/v1/validation/grpcroute.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var (
+	// repeatableGRPCRouteFilters are filter types that are allowed to be
+	// repeated multiple times in a rule.
+	repeatableGRPCRouteFilters = []gatewayv1.GRPCRouteFilterType{
+		gatewayv1.GRPCRouteFilterExtensionRef,
+		gatewayv1.GRPCRouteFilterRequestMirror,
+	}
+	validServiceName      = `^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$`
+	validServiceNameRegex = regexp.MustCompile(validServiceName)
+	validMethodName       = `^[A-Za-z_][A-Za-z_0-9]*$`
+	validMethodNameRegex  = regexp.MustCompile(validMethodName)
+)
+
+// ValidateGRPCRoute validates GRPCRoute according to the Gateway API specification.
+// For additional details of the GRPCRoute spec, refer to:
+// https://gateway-api.sigs.k8s.io/v1alpha2/reference/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRoute
+func ValidateGRPCRoute(route *gatewayv1.GRPCRoute) field.ErrorList {
+	return validateGRPCRouteSpec(&route.Spec, field.NewPath("spec"))
+}
+
+// validateRouteSpec validates that required fields of spec are set according to the
+// Gateway API specification.
+func validateGRPCRouteSpec(spec *gatewayv1.GRPCRouteSpec, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	errs = append(errs, validateGRPCRouteRules(spec.Rules, path.Child("rules"))...)
+	errs = append(errs, validateParentRefs(spec.ParentRefs, path.Child("spec"))...)
+	errs = append(errs, validateGRPCRouteBackendServicePorts(spec.Rules, path.Child("rules"))...)
+	return errs
+}
+
+// validateGRPCRouteRules validates whether required fields of rules are set according
+// to the Gateway API specification.
+func validateGRPCRouteRules(rules []gatewayv1.GRPCRouteRule, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, rule := range rules {
+		errs = append(errs, validateRuleMatches(rule.Matches, path.Index(i).Child("matches"))...)
+		errs = append(errs, validateGRPCRouteFilters(rule.Filters, path.Index(i).Child(("filters")))...)
+		for j, backendRef := range rule.BackendRefs {
+			errs = append(errs, validateGRPCRouteFilters(backendRef.Filters, path.Child("rules").Index(i).Child("backendRefs").Index(j))...)
+		}
+	}
+	return errs
+}
+
+// validateGRPCRouteBackendServicePorts validates that v1.Service backends always have a port.
+func validateGRPCRouteBackendServicePorts(rules []gatewayv1.GRPCRouteRule, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+
+	for i, rule := range rules {
+		path = path.Index(i).Child("backendRefs")
+		for i, ref := range rule.BackendRefs {
+			if ref.BackendObjectReference.Group != nil &&
+				*ref.BackendObjectReference.Group != "" {
+				continue
+			}
+
+			if ref.BackendObjectReference.Kind != nil &&
+				*ref.BackendObjectReference.Kind != "Service" {
+				continue
+			}
+
+			if ref.BackendObjectReference.Port == nil {
+				errs = append(errs, field.Required(path.Index(i).Child("port"), "missing port for Service reference"))
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateRuleMatches validates GRPCMethodMatch
+func validateRuleMatches(matches []gatewayv1.GRPCRouteMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, m := range matches {
+		if m.Method != nil {
+			if m.Method.Service == nil && m.Method.Method == nil {
+				errs = append(errs, field.Required(path.Index(i).Child("method"), "one or both of `service` or `method` must be specified"))
+			}
+			// GRPCRoute method matcher admits two types: Exact and RegularExpression.
+			// If not specified, the match will be treated as type Exact (also the default value for this field).
+			if m.Method.Type == nil || *m.Method.Type == gatewayv1.GRPCMethodMatchExact {
+				if m.Method.Service != nil && !validServiceNameRegex.MatchString(*m.Method.Service) {
+					errs = append(errs, field.Invalid(path.Index(i).Child("method"), *m.Method.Service,
+						fmt.Sprintf("must only contain valid characters (matching %s)", validServiceName)))
+				}
+				if m.Method.Method != nil && !validMethodNameRegex.MatchString(*m.Method.Method) {
+					errs = append(errs, field.Invalid(path.Index(i).Child("method"), *m.Method.Method,
+						fmt.Sprintf("must only contain valid characters (matching %s)", validMethodName)))
+				}
+			}
+		}
+		if m.Headers != nil {
+			errs = append(errs, validateGRPCHeaderMatches(m.Headers, path.Index(i).Child("headers"))...)
+		}
+	}
+	return errs
+}
+
+// validateGRPCHeaderMatches validates that no header name is matched more than
+// once (case-insensitive), and that at least one of service or method was
+// provided.
+func validateGRPCHeaderMatches(matches []gatewayv1.GRPCHeaderMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	counts := map[string]int{}
+
+	for _, match := range matches {
+		// Header names are case-insensitive.
+		counts[strings.ToLower(string(match.Name))]++
+	}
+
+	for name, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path, http.CanonicalHeaderKey(name), "cannot match the same header multiple times in the same rule"))
+		}
+	}
+
+	return errs
+}
+
+// validateGRPCRouteFilterType validates that only the expected fields are
+// set for the specified filter type.
+func validateGRPCRouteFilterType(filter gatewayv1.GRPCRouteFilter, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if filter.ExtensionRef != nil && filter.Type != gatewayv1.GRPCRouteFilterExtensionRef {
+		errs = append(errs, field.Invalid(path, filter.ExtensionRef, "must be nil if the GRPCRouteFilter.Type is not ExtensionRef"))
+	}
+	if filter.ExtensionRef == nil && filter.Type == gatewayv1.GRPCRouteFilterExtensionRef {
+		errs = append(errs, field.Required(path, "filter.ExtensionRef must be specified for ExtensionRef GRPCRouteFilter.Type"))
+	}
+	if filter.RequestHeaderModifier != nil && filter.Type != gatewayv1.GRPCRouteFilterRequestHeaderModifier {
+		errs = append(errs, field.Invalid(path, filter.RequestHeaderModifier, "must be nil if the GRPCRouteFilter.Type is not RequestHeaderModifier"))
+	}
+	if filter.RequestHeaderModifier == nil && filter.Type == gatewayv1.GRPCRouteFilterRequestHeaderModifier {
+		errs = append(errs, field.Required(path, "filter.RequestHeaderModifier must be specified for RequestHeaderModifier GRPCRouteFilter.Type"))
+	}
+	if filter.ResponseHeaderModifier != nil && filter.Type != gatewayv1.GRPCRouteFilterResponseHeaderModifier {
+		errs = append(errs, field.Invalid(path, filter.ResponseHeaderModifier, "must be nil if the GRPCRouteFilter.Type is not ResponseHeaderModifier"))
+	}
+	if filter.ResponseHeaderModifier == nil && filter.Type == gatewayv1.GRPCRouteFilterResponseHeaderModifier {
+		errs = append(errs, field.Required(path, "filter.ResponseHeaderModifier must be specified for ResponseHeaderModifier GRPCRouteFilter.Type"))
+	}
+	if filter.RequestMirror != nil && filter.Type != gatewayv1.GRPCRouteFilterRequestMirror {
+		errs = append(errs, field.Invalid(path, filter.RequestMirror, "must be nil if the GRPCRouteFilter.Type is not RequestMirror"))
+	}
+	if filter.RequestMirror == nil && filter.Type == gatewayv1.GRPCRouteFilterRequestMirror {
+		errs = append(errs, field.Required(path, "filter.RequestMirror must be specified for RequestMirror GRPCRouteFilter.Type"))
+	}
+	return errs
+}
+
+// validateGRPCRouteFilters validates that a list of core and extended filters
+// is used at most once and that the filter type matches its value
+func validateGRPCRouteFilters(filters []gatewayv1.GRPCRouteFilter, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	counts := map[gatewayv1.GRPCRouteFilterType]int{}
+
+	for i, filter := range filters {
+		counts[filter.Type]++
+		if filter.RequestHeaderModifier != nil {
+			errs = append(errs, validateGRPCHeaderModifier(*filter.RequestHeaderModifier, path.Index(i).Child("requestHeaderModifier"))...)
+		}
+		if filter.ResponseHeaderModifier != nil {
+			errs = append(errs, validateGRPCHeaderModifier(*filter.ResponseHeaderModifier, path.Index(i).Child("responseHeaderModifier"))...)
+		}
+		errs = append(errs, validateGRPCRouteFilterType(filter, path.Index(i))...)
+	}
+	// repeatableGRPCRouteFilters filters can be used more than once
+	for _, key := range repeatableGRPCRouteFilters {
+		delete(counts, key)
+	}
+
+	for filterType, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path, filterType, "cannot be used multiple times in the same rule"))
+		}
+	}
+	return errs
+}
+
+// validateGRPCHeaderModifier ensures that multiple actions cannot be set for
+// the same header.
+func validateGRPCHeaderModifier(filter gatewayv1.HTTPHeaderFilter, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	singleAction := make(map[string]bool)
+	for i, action := range filter.Add {
+		if needsErr, ok := singleAction[strings.ToLower(string(action.Name))]; ok {
+			if needsErr {
+				errs = append(errs, field.Invalid(path.Child("add"), filter.Add[i], "cannot specify multiple actions for header"))
+			}
+			singleAction[strings.ToLower(string(action.Name))] = false
+		} else {
+			singleAction[strings.ToLower(string(action.Name))] = true
+		}
+	}
+	for i, action := range filter.Set {
+		if needsErr, ok := singleAction[strings.ToLower(string(action.Name))]; ok {
+			if needsErr {
+				errs = append(errs, field.Invalid(path.Child("set"), filter.Set[i], "cannot specify multiple actions for header"))
+			}
+			singleAction[strings.ToLower(string(action.Name))] = false
+		} else {
+			singleAction[strings.ToLower(string(action.Name))] = true
+		}
+	}
+	for i, name := range filter.Remove {
+		if needsErr, ok := singleAction[strings.ToLower(name)]; ok {
+			if needsErr {
+				errs = append(errs, field.Invalid(path.Child("remove"), filter.Remove[i], "cannot specify multiple actions for header"))
+			}
+			singleAction[strings.ToLower(name)] = false
+		} else {
+			singleAction[strings.ToLower(name)] = true
+		}
+	}
+	return errs
+}

--- a/pkg/apis/gateway/v1/validation/grpcroute_test.go
+++ b/pkg/apis/gateway/v1/validation/grpcroute_test.go
@@ -1,0 +1,445 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestValidateGRPCRoute(t *testing.T) {
+	t.Parallel()
+
+	service := "foo.Test.Example"
+	method := "Login"
+	regex := ".*"
+
+	tests := []struct {
+		name  string
+		rules []gatewayv1.GRPCRouteRule
+		errs  field.ErrorList
+	}{
+		{
+			name: "valid GRPCRoute with 1 service in GRPCMethodMatch field",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{
+						{
+							Method: &gatewayv1.GRPCMethodMatch{
+								Service: &service,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid GRPCRoute with 1 method in GRPCMethodMatch field",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{
+						{
+							Method: &gatewayv1.GRPCMethodMatch{
+								Method: &method,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid GRPCRoute missing service or method in GRPCMethodMatch field",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{
+						{
+							Method: &gatewayv1.GRPCMethodMatch{
+								Service: nil,
+								Method:  nil,
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{
+				{
+					Type:   field.ErrorTypeRequired,
+					Field:  "spec.rules[0].matches[0].method",
+					Detail: "one or both of `service` or `method` must be specified",
+				},
+			},
+		},
+		{
+			name: "GRPCRoute use regex in service and method with undefined match type",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{
+						{
+							Method: &gatewayv1.GRPCMethodMatch{
+								Service: &regex,
+								Method:  &regex,
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{
+				{
+					Type:     field.ErrorTypeInvalid,
+					BadValue: regex,
+					Field:    "spec.rules[0].matches[0].method",
+					Detail:   `must only contain valid characters (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)`,
+				},
+				{
+					Type:     field.ErrorTypeInvalid,
+					BadValue: regex,
+					Field:    "spec.rules[0].matches[0].method",
+					Detail:   `must only contain valid characters (matching ^[A-Za-z_][A-Za-z_0-9]*$)`,
+				},
+			},
+		},
+		{
+			name: "GRPCRoute use regex in service and method with match type Exact",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{
+						{
+							Method: &gatewayv1.GRPCMethodMatch{
+								Service: &regex,
+								Method:  &regex,
+								Type:    ptrTo(gatewayv1.GRPCMethodMatchExact),
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{
+				{
+					Type:     field.ErrorTypeInvalid,
+					BadValue: regex,
+					Field:    "spec.rules[0].matches[0].method",
+					Detail:   `must only contain valid characters (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)`,
+				},
+				{
+					Type:     field.ErrorTypeInvalid,
+					BadValue: regex,
+					Field:    "spec.rules[0].matches[0].method",
+					Detail:   `must only contain valid characters (matching ^[A-Za-z_][A-Za-z_0-9]*$)`,
+				},
+			},
+		},
+		{
+			name: "GRPCRoute use regex in service and method with match type RegularExpression",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{
+						{
+							Method: &gatewayv1.GRPCMethodMatch{
+								Service: &regex,
+								Method:  &regex,
+								Type:    ptrTo(gatewayv1.GRPCMethodMatchRegularExpression),
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{},
+		},
+		{
+			name: "GRPCRoute use valid service and method with undefined match type",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{
+						{
+							Method: &gatewayv1.GRPCMethodMatch{
+								Service: &service,
+								Method:  &method,
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{},
+		},
+		{
+			name: "GRPCRoute use valid service and method with match type Exact",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{
+						{
+							Method: &gatewayv1.GRPCMethodMatch{
+								Service: &service,
+								Method:  &method,
+								Type:    ptrTo(gatewayv1.GRPCMethodMatchExact),
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{},
+		},
+		{
+			name: "GRPCRoute with duplicate ExtensionRef filters",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Filters: []gatewayv1.GRPCRouteFilter{{
+						Type: "ExtensionRef",
+						ExtensionRef: &gatewayv1.LocalObjectReference{
+							Kind: "Example1",
+						},
+					}, {
+						Type: "ExtensionRef",
+						ExtensionRef: &gatewayv1.LocalObjectReference{
+							Kind: "Example2",
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "GRPCRoute with duplicate RequestMirror filters",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Filters: []gatewayv1.GRPCRouteFilter{{
+						Type: "RequestMirror",
+						RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1.BackendObjectReference{
+								Name: "Example1",
+							},
+						},
+					}, {
+						Type: "RequestMirror",
+						RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1.BackendObjectReference{
+								Name: "Example2",
+							},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "invalid GRPCRoute with duplicate RequestHeaderModifier filters",
+			rules: []gatewayv1.GRPCRouteRule{
+				{
+					Filters: []gatewayv1.GRPCRouteFilter{{
+						Type: "RequestHeaderModifier",
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{
+								{
+									Name:  "special-header",
+									Value: "foo",
+								},
+							},
+						},
+					}, {
+						Type: "RequestHeaderModifier",
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Add: []gatewayv1.HTTPHeader{
+								{
+									Name:  "my-header",
+									Value: "bar",
+								},
+							},
+						},
+					}},
+				},
+			},
+			errs: field.ErrorList{
+				{
+					Type:     field.ErrorTypeInvalid,
+					BadValue: "RequestHeaderModifier",
+					Field:    "spec.rules[0].filters",
+					Detail:   "cannot be used multiple times in the same rule",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			route := gatewayv1.GRPCRoute{Spec: gatewayv1.GRPCRouteSpec{Rules: tc.rules}}
+			errs := ValidateGRPCRoute(&route)
+			if len(errs) != len(tc.errs) {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), len(tc.errs), errs)
+				t.FailNow()
+			}
+			for i := 0; i < len(errs); i++ {
+				realErr := errs[i].Error()
+				expectedErr := tc.errs[i].Error()
+				if realErr != expectedErr {
+					t.Errorf("expect error message: %s, but got: %s", expectedErr, realErr)
+					t.FailNow()
+				}
+			}
+		})
+	}
+}
+
+func TestValidateGRPCBackendUniqueFilters(t *testing.T) {
+	var testService gatewayv1.ObjectName = "testService"
+	var specialService gatewayv1.ObjectName = "specialService"
+	tests := []struct {
+		name     string
+		rules    []gatewayv1.GRPCRouteRule
+		errCount int
+	}{{
+		name:     "valid grpcRoute Rules backendref filters",
+		errCount: 0,
+		rules: []gatewayv1.GRPCRouteRule{{
+			BackendRefs: []gatewayv1.GRPCBackendRef{
+				{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: testService,
+							Port: ptrTo(gatewayv1.PortNumber(8080)),
+						},
+						Weight: ptrTo(int32(100)),
+					},
+					Filters: []gatewayv1.GRPCRouteFilter{
+						{
+							Type: gatewayv1.GRPCRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name: testService,
+									Port: ptrTo(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+	}, {
+		name:     "valid grpcRoute Rules duplicate mirror filter",
+		errCount: 0,
+		rules: []gatewayv1.GRPCRouteRule{{
+			BackendRefs: []gatewayv1.GRPCBackendRef{
+				{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: testService,
+							Port: ptrTo(gatewayv1.PortNumber(8080)),
+						},
+					},
+					Filters: []gatewayv1.GRPCRouteFilter{
+						{
+							Type: gatewayv1.GRPCRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name: testService,
+									Port: ptrTo(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+						{
+							Type: gatewayv1.GRPCRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name: specialService,
+									Port: ptrTo(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := gatewayv1.GRPCRoute{Spec: gatewayv1.GRPCRouteSpec{Rules: tc.rules}}
+			errs := ValidateGRPCRoute(&route)
+			if len(errs) != tc.errCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}
+
+func TestValidateGRPCHeaderMatches(t *testing.T) {
+	tests := []struct {
+		name          string
+		headerMatches []gatewayv1.GRPCHeaderMatch
+		expectErr     string
+	}{{
+		name:          "no header matches",
+		headerMatches: nil,
+		expectErr:     "",
+	}, {
+		name: "no header matched more than once",
+		headerMatches: []gatewayv1.GRPCHeaderMatch{
+			{Name: "Header-Name-1", Value: "val-1"},
+			{Name: "Header-Name-2", Value: "val-2"},
+			{Name: "Header-Name-3", Value: "val-3"},
+		},
+		expectErr: "",
+	}, {
+		name: "header matched more than once (same case)",
+		headerMatches: []gatewayv1.GRPCHeaderMatch{
+			{Name: "Header-Name-1", Value: "val-1"},
+			{Name: "Header-Name-2", Value: "val-2"},
+			{Name: "Header-Name-1", Value: "val-3"},
+		},
+		expectErr: "spec.rules[0].matches[0].headers: Invalid value: \"Header-Name-1\": cannot match the same header multiple times in the same rule",
+	}, {
+		name: "header matched more than once (different case)",
+		headerMatches: []gatewayv1.GRPCHeaderMatch{
+			{Name: "Header-Name-1", Value: "val-1"},
+			{Name: "Header-Name-2", Value: "val-2"},
+			{Name: "HEADER-NAME-2", Value: "val-3"},
+		},
+		expectErr: "spec.rules[0].matches[0].headers: Invalid value: \"Header-Name-2\": cannot match the same header multiple times in the same rule",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := gatewayv1.GRPCRoute{Spec: gatewayv1.GRPCRouteSpec{
+				Rules: []gatewayv1.GRPCRouteRule{{
+					Matches: []gatewayv1.GRPCRouteMatch{{
+						Headers: tc.headerMatches,
+					}},
+					BackendRefs: []gatewayv1.GRPCBackendRef{{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: gatewayv1.ObjectName("test"),
+								Port: ptrTo(gatewayv1.PortNumber(8080)),
+							},
+						},
+					}},
+				}},
+			}}
+
+			errs := ValidateGRPCRoute(&route)
+			if len(tc.expectErr) == 0 {
+				assert.Emptyf(t, errs, "expected no errors, got %d errors: %s", len(errs), errs)
+			} else {
+				require.Lenf(t, errs, 1, "expected one error, got %d errors: %s", len(errs), errs)
+				assert.Equal(t, tc.expectErr, errs[0].Error())
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1/validation/httproute.go
+++ b/pkg/apis/gateway/v1/validation/httproute.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var (
+	// repeatableHTTPRouteFilters are filter types that are allowed to be
+	// repeated multiple times in a rule.
+	repeatableHTTPRouteFilters = []gatewayv1.HTTPRouteFilterType{
+		gatewayv1.HTTPRouteFilterExtensionRef,
+		gatewayv1.HTTPRouteFilterRequestMirror,
+	}
+
+	// Invalid path sequences and suffixes, primarily related to directory traversal
+	invalidPathSequences = []string{"//", "/./", "/../", "%2f", "%2F", "#"}
+	invalidPathSuffixes  = []string{"/..", "/."}
+
+	// All valid path characters per RFC-3986
+	validPathCharacters = "^(?:[A-Za-z0-9\\/\\-._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$"
+)
+
+// ValidateHTTPRoute validates HTTPRoute according to the Gateway API specification.
+// For additional details of the HTTPRoute spec, refer to:
+// https://gateway-api.sigs.k8s.io/v1beta1/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute
+func ValidateHTTPRoute(route *gatewayv1.HTTPRoute) field.ErrorList {
+	return ValidateHTTPRouteSpec(&route.Spec, field.NewPath("spec"))
+}
+
+// ValidateHTTPRouteSpec validates that required fields of spec are set according to the
+// HTTPRoute specification.
+func ValidateHTTPRouteSpec(spec *gatewayv1.HTTPRouteSpec, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, rule := range spec.Rules {
+		errs = append(errs, validateHTTPRouteFilters(rule.Filters, rule.Matches, path.Child("rules").Index(i))...)
+		errs = append(errs, validateRequestRedirectFiltersWithBackendRefs(rule, path.Child("rules").Index(i))...)
+		for j, backendRef := range rule.BackendRefs {
+			errs = append(errs, validateHTTPRouteFilters(backendRef.Filters, rule.Matches, path.Child("rules").Index(i).Child("backendRefs").Index(j))...)
+		}
+		for j, m := range rule.Matches {
+			matchPath := path.Child("rules").Index(i).Child("matches").Index(j)
+
+			if m.Path != nil {
+				errs = append(errs, validateHTTPPathMatch(m.Path, matchPath.Child("path"))...)
+			}
+			if len(m.Headers) > 0 {
+				errs = append(errs, validateHTTPHeaderMatches(m.Headers, matchPath.Child("headers"))...)
+			}
+			if len(m.QueryParams) > 0 {
+				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, matchPath.Child("queryParams"))...)
+			}
+		}
+
+		if rule.Timeouts != nil {
+			errs = append(errs, validateHTTPRouteTimeouts(rule.Timeouts, path.Child("rules").Child("timeouts"))...)
+		}
+	}
+	errs = append(errs, validateHTTPRouteBackendServicePorts(spec.Rules, path.Child("rules"))...)
+	errs = append(errs, ValidateParentRefs(spec.ParentRefs, path.Child("spec"))...)
+	return errs
+}
+
+// validateRequestRedirectFiltersWithBackendRefs validates that RequestRedirect filters are not used with backendRefs
+func validateRequestRedirectFiltersWithBackendRefs(rule gatewayv1.HTTPRouteRule, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for _, filter := range rule.Filters {
+		if filter.RequestRedirect != nil && len(rule.BackendRefs) > 0 {
+			errs = append(errs, field.Invalid(path.Child("filters"), gatewayv1.HTTPRouteFilterRequestRedirect, "RequestRedirect filter is not allowed with backendRefs"))
+		}
+	}
+	return errs
+}
+
+// validateHTTPRouteBackendServicePorts validates that v1.Service backends always have a port.
+func validateHTTPRouteBackendServicePorts(rules []gatewayv1.HTTPRouteRule, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+
+	for i, rule := range rules {
+		path = path.Index(i).Child("backendRefs")
+		for i, ref := range rule.BackendRefs {
+			if ref.BackendObjectReference.Group != nil &&
+				*ref.BackendObjectReference.Group != "" {
+				continue
+			}
+
+			if ref.BackendObjectReference.Kind != nil &&
+				*ref.BackendObjectReference.Kind != "Service" {
+				continue
+			}
+
+			if ref.BackendObjectReference.Port == nil {
+				errs = append(errs, field.Required(path.Index(i).Child("port"), "missing port for Service reference"))
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateHTTPRouteFilters validates that a list of core and extended filters
+// is used at most once and that the filter type matches its value
+func validateHTTPRouteFilters(filters []gatewayv1.HTTPRouteFilter, matches []gatewayv1.HTTPRouteMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	counts := map[gatewayv1.HTTPRouteFilterType]int{}
+
+	for i, filter := range filters {
+		counts[filter.Type]++
+		if filter.RequestRedirect != nil && filter.RequestRedirect.Path != nil {
+			errs = append(errs, validateHTTPPathModifier(*filter.RequestRedirect.Path, matches, path.Index(i).Child("requestRedirect", "path"))...)
+		}
+		if filter.URLRewrite != nil && filter.URLRewrite.Path != nil {
+			errs = append(errs, validateHTTPPathModifier(*filter.URLRewrite.Path, matches, path.Index(i).Child("urlRewrite", "path"))...)
+		}
+		if filter.RequestHeaderModifier != nil {
+			errs = append(errs, validateHTTPHeaderModifier(*filter.RequestHeaderModifier, path.Index(i).Child("requestHeaderModifier"))...)
+		}
+		if filter.ResponseHeaderModifier != nil {
+			errs = append(errs, validateHTTPHeaderModifier(*filter.ResponseHeaderModifier, path.Index(i).Child("responseHeaderModifier"))...)
+		}
+		errs = append(errs, validateHTTPRouteFilterTypeMatchesValue(filter, path.Index(i))...)
+	}
+
+	if counts[gatewayv1.HTTPRouteFilterRequestRedirect] > 0 && counts[gatewayv1.HTTPRouteFilterURLRewrite] > 0 {
+		errs = append(errs, field.Invalid(path.Child("filters"), gatewayv1.HTTPRouteFilterRequestRedirect, "may specify either httpRouteFilterRequestRedirect or httpRouteFilterRequestRewrite, but not both"))
+	}
+
+	// repeatableHTTPRouteFilters filters can be used more than once
+	for _, key := range repeatableHTTPRouteFilters {
+		delete(counts, key)
+	}
+
+	for filterType, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path.Child("filters"), filterType, "cannot be used multiple times in the same rule"))
+		}
+	}
+	return errs
+}
+
+// webhook validation of HTTPPathMatch
+func validateHTTPPathMatch(path *gatewayv1.HTTPPathMatch, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if path.Type == nil {
+		return append(allErrs, field.Required(fldPath.Child("type"), "must be specified"))
+	}
+
+	if path.Value == nil {
+		return append(allErrs, field.Required(fldPath.Child("value"), "must be specified"))
+	}
+
+	switch *path.Type {
+	case gatewayv1.PathMatchExact, gatewayv1.PathMatchPathPrefix:
+		if !strings.HasPrefix(*path.Value, "/") {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("value"), *path.Value, "must be an absolute path"))
+		}
+		if len(*path.Value) > 0 {
+			for _, invalidSeq := range invalidPathSequences {
+				if strings.Contains(*path.Value, invalidSeq) {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("value"), *path.Value, fmt.Sprintf("must not contain %q", invalidSeq)))
+				}
+			}
+
+			for _, invalidSuff := range invalidPathSuffixes {
+				if strings.HasSuffix(*path.Value, invalidSuff) {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("value"), *path.Value, fmt.Sprintf("cannot end with '%s'", invalidSuff)))
+				}
+			}
+		}
+
+		r, err := regexp.Compile(validPathCharacters)
+		if err != nil {
+			allErrs = append(allErrs, field.InternalError(fldPath.Child("value"),
+				fmt.Errorf("could not compile path matching regex: %w", err)))
+		} else if !r.MatchString(*path.Value) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("value"), *path.Value,
+				fmt.Sprintf("must only contain valid characters (matching %s)", validPathCharacters)))
+		}
+
+	case gatewayv1.PathMatchRegularExpression:
+	default:
+		pathTypes := []string{string(gatewayv1.PathMatchExact), string(gatewayv1.PathMatchPathPrefix), string(gatewayv1.PathMatchRegularExpression)}
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), *path.Type, pathTypes))
+	}
+	return allErrs
+}
+
+// validateHTTPHeaderMatches validates that no header name
+// is matched more than once (case-insensitive).
+func validateHTTPHeaderMatches(matches []gatewayv1.HTTPHeaderMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	counts := map[string]int{}
+
+	for _, match := range matches {
+		// Header names are case-insensitive.
+		counts[strings.ToLower(string(match.Name))]++
+	}
+
+	for name, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path, http.CanonicalHeaderKey(name), "cannot match the same header multiple times in the same rule"))
+		}
+	}
+
+	return errs
+}
+
+// validateHTTPQueryParamMatches validates that no query param name
+// is matched more than once (case-sensitive).
+func validateHTTPQueryParamMatches(matches []gatewayv1.HTTPQueryParamMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	counts := map[string]int{}
+
+	for _, match := range matches {
+		// Query param names are case-sensitive.
+		counts[string(match.Name)]++
+	}
+
+	for name, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path, name, "cannot match the same query parameter multiple times in the same rule"))
+		}
+	}
+
+	return errs
+}
+
+// validateHTTPRouteFilterTypeMatchesValue validates that only the expected fields are
+// set for the specified filter type.
+func validateHTTPRouteFilterTypeMatchesValue(filter gatewayv1.HTTPRouteFilter, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if filter.ExtensionRef != nil && filter.Type != gatewayv1.HTTPRouteFilterExtensionRef {
+		errs = append(errs, field.Invalid(path, filter.ExtensionRef, "must be nil if the HTTPRouteFilter.Type is not ExtensionRef"))
+	}
+	if filter.ExtensionRef == nil && filter.Type == gatewayv1.HTTPRouteFilterExtensionRef {
+		errs = append(errs, field.Required(path, "filter.ExtensionRef must be specified for ExtensionRef HTTPRouteFilter.Type"))
+	}
+	if filter.RequestHeaderModifier != nil && filter.Type != gatewayv1.HTTPRouteFilterRequestHeaderModifier {
+		errs = append(errs, field.Invalid(path, filter.RequestHeaderModifier, "must be nil if the HTTPRouteFilter.Type is not RequestHeaderModifier"))
+	}
+	if filter.RequestHeaderModifier == nil && filter.Type == gatewayv1.HTTPRouteFilterRequestHeaderModifier {
+		errs = append(errs, field.Required(path, "filter.RequestHeaderModifier must be specified for RequestHeaderModifier HTTPRouteFilter.Type"))
+	}
+	if filter.ResponseHeaderModifier != nil && filter.Type != gatewayv1.HTTPRouteFilterResponseHeaderModifier {
+		errs = append(errs, field.Invalid(path, filter.ResponseHeaderModifier, "must be nil if the HTTPRouteFilter.Type is not ResponseHeaderModifier"))
+	}
+	if filter.ResponseHeaderModifier == nil && filter.Type == gatewayv1.HTTPRouteFilterResponseHeaderModifier {
+		errs = append(errs, field.Required(path, "filter.ResponseHeaderModifier must be specified for ResponseHeaderModifier HTTPRouteFilter.Type"))
+	}
+	if filter.RequestMirror != nil && filter.Type != gatewayv1.HTTPRouteFilterRequestMirror {
+		errs = append(errs, field.Invalid(path, filter.RequestMirror, "must be nil if the HTTPRouteFilter.Type is not RequestMirror"))
+	}
+	if filter.RequestMirror == nil && filter.Type == gatewayv1.HTTPRouteFilterRequestMirror {
+		errs = append(errs, field.Required(path, "filter.RequestMirror must be specified for RequestMirror HTTPRouteFilter.Type"))
+	}
+	if filter.RequestRedirect != nil && filter.Type != gatewayv1.HTTPRouteFilterRequestRedirect {
+		errs = append(errs, field.Invalid(path, filter.RequestRedirect, "must be nil if the HTTPRouteFilter.Type is not RequestRedirect"))
+	}
+	if filter.RequestRedirect == nil && filter.Type == gatewayv1.HTTPRouteFilterRequestRedirect {
+		errs = append(errs, field.Required(path, "filter.RequestRedirect must be specified for RequestRedirect HTTPRouteFilter.Type"))
+	}
+	if filter.URLRewrite != nil && filter.Type != gatewayv1.HTTPRouteFilterURLRewrite {
+		errs = append(errs, field.Invalid(path, filter.URLRewrite, "must be nil if the HTTPRouteFilter.Type is not URLRewrite"))
+	}
+	if filter.URLRewrite == nil && filter.Type == gatewayv1.HTTPRouteFilterURLRewrite {
+		errs = append(errs, field.Required(path, "filter.URLRewrite must be specified for URLRewrite HTTPRouteFilter.Type"))
+	}
+	return errs
+}
+
+// validateHTTPPathModifier validates that only the expected fields are set in a
+// path modifier.
+func validateHTTPPathModifier(modifier gatewayv1.HTTPPathModifier, matches []gatewayv1.HTTPRouteMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if modifier.ReplaceFullPath != nil && modifier.Type != gatewayv1.FullPathHTTPPathModifier {
+		errs = append(errs, field.Invalid(path, modifier.ReplaceFullPath, "must be nil if the HTTPRouteFilter.Type is not ReplaceFullPath"))
+	}
+	if modifier.ReplaceFullPath == nil && modifier.Type == gatewayv1.FullPathHTTPPathModifier {
+		errs = append(errs, field.Invalid(path, modifier.ReplaceFullPath, "must not be nil if the HTTPRouteFilter.Type is ReplaceFullPath"))
+	}
+	if modifier.ReplacePrefixMatch != nil && modifier.Type != gatewayv1.PrefixMatchHTTPPathModifier {
+		errs = append(errs, field.Invalid(path, modifier.ReplacePrefixMatch, "must be nil if the HTTPRouteFilter.Type is not ReplacePrefixMatch"))
+	}
+	if modifier.ReplacePrefixMatch == nil && modifier.Type == gatewayv1.PrefixMatchHTTPPathModifier {
+		errs = append(errs, field.Invalid(path, modifier.ReplacePrefixMatch, "must not be nil if the HTTPRouteFilter.Type is ReplacePrefixMatch"))
+	}
+
+	if modifier.Type == gatewayv1.PrefixMatchHTTPPathModifier && modifier.ReplacePrefixMatch != nil {
+		if !hasExactlyOnePrefixMatch(matches) {
+			errs = append(errs, field.Invalid(path, modifier.ReplacePrefixMatch, "exactly one PathPrefix match must be specified to use this path modifier"))
+		}
+	}
+	return errs
+}
+
+func validateHTTPHeaderModifier(filter gatewayv1.HTTPHeaderFilter, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	singleAction := make(map[string]bool)
+	for i, action := range filter.Add {
+		if needsErr, ok := singleAction[strings.ToLower(string(action.Name))]; ok {
+			if needsErr {
+				errs = append(errs, field.Invalid(path.Child("add"), filter.Add[i], "cannot specify multiple actions for header"))
+			}
+			singleAction[strings.ToLower(string(action.Name))] = false
+		} else {
+			singleAction[strings.ToLower(string(action.Name))] = true
+		}
+	}
+	for i, action := range filter.Set {
+		if needsErr, ok := singleAction[strings.ToLower(string(action.Name))]; ok {
+			if needsErr {
+				errs = append(errs, field.Invalid(path.Child("set"), filter.Set[i], "cannot specify multiple actions for header"))
+			}
+			singleAction[strings.ToLower(string(action.Name))] = false
+		} else {
+			singleAction[strings.ToLower(string(action.Name))] = true
+		}
+	}
+	for i, name := range filter.Remove {
+		if needsErr, ok := singleAction[strings.ToLower(name)]; ok {
+			if needsErr {
+				errs = append(errs, field.Invalid(path.Child("remove"), filter.Remove[i], "cannot specify multiple actions for header"))
+			}
+			singleAction[strings.ToLower(name)] = false
+		} else {
+			singleAction[strings.ToLower(name)] = true
+		}
+	}
+	return errs
+}
+
+func validateHTTPRouteTimeouts(timeouts *gatewayv1.HTTPRouteTimeouts, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if timeouts.BackendRequest != nil {
+		backendTimeout, _ := time.ParseDuration((string)(*timeouts.BackendRequest))
+		if timeouts.Request != nil {
+			timeout, _ := time.ParseDuration((string)(*timeouts.Request))
+			if backendTimeout > timeout && timeout != 0 {
+				errs = append(errs, field.Invalid(path.Child("backendRequest"), backendTimeout, "backendRequest timeout cannot be longer than request timeout"))
+			}
+		}
+	}
+
+	return errs
+}
+
+func hasExactlyOnePrefixMatch(matches []gatewayv1.HTTPRouteMatch) bool {
+	if len(matches) != 1 || matches[0].Path == nil {
+		return false
+	}
+	pathMatchType := matches[0].Path.Type
+	if *pathMatchType != gatewayv1.PathMatchPathPrefix {
+		return false
+	}
+
+	return true
+}

--- a/pkg/apis/gateway/v1/validation/httproute.go
+++ b/pkg/apis/gateway/v1/validation/httproute.go
@@ -373,9 +373,6 @@ func hasExactlyOnePrefixMatch(matches []gatewayv1.HTTPRouteMatch) bool {
 		return false
 	}
 	pathMatchType := matches[0].Path.Type
-	if *pathMatchType != gatewayv1.PathMatchPathPrefix {
-		return false
-	}
 
-	return true
+	return *pathMatchType != gatewayv1.PathMatchPathPrefix
 }

--- a/pkg/apis/gateway/v1/validation/httproute.go
+++ b/pkg/apis/gateway/v1/validation/httproute.go
@@ -374,5 +374,5 @@ func hasExactlyOnePrefixMatch(matches []gatewayv1.HTTPRouteMatch) bool {
 	}
 	pathMatchType := matches[0].Path.Type
 
-	return *pathMatchType != gatewayv1.PathMatchPathPrefix
+	return *pathMatchType == gatewayv1.PathMatchPathPrefix
 }

--- a/pkg/apis/gateway/v1/validation/httproute_test.go
+++ b/pkg/apis/gateway/v1/validation/httproute_test.go
@@ -1,0 +1,1307 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestValidateHTTPRoute(t *testing.T) {
+	testService := gatewayv1.ObjectName("test-service")
+	pathPrefixMatchType := gatewayv1.PathMatchPathPrefix
+
+	tests := []struct {
+		name     string
+		rules    []gatewayv1.HTTPRouteRule
+		errCount int
+	}{{
+		name:     "valid httpRoute with no filters",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{
+			{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptrTo(gatewayv1.PathMatchType("PathPrefix")),
+							Value: ptrTo("/"),
+						},
+					},
+				},
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: testService,
+								Port: ptrTo(gatewayv1.PortNumber(8080)),
+							},
+							Weight: ptrTo(int32(100)),
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name:     "valid httpRoute with 1 filter",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{
+			{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptrTo(gatewayv1.PathMatchType("PathPrefix")),
+							Value: ptrTo("/"),
+						},
+					},
+				},
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1.BackendObjectReference{
+								Name: testService,
+								Port: ptrTo(gatewayv1.PortNumber(8081)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name:     "invalid httpRoute with 2 extended filters",
+		errCount: 1,
+		rules: []gatewayv1.HTTPRouteRule{
+			{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptrTo(gatewayv1.PathMatchType("PathPrefix")),
+							Value: ptrTo("/"),
+						},
+					},
+				},
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterURLRewrite,
+						URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+							Path: &gatewayv1.HTTPPathModifier{
+								Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+								ReplacePrefixMatch: ptrTo("foo"),
+							},
+						},
+					},
+					{
+						Type: gatewayv1.HTTPRouteFilterURLRewrite,
+						URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+							Path: &gatewayv1.HTTPPathModifier{
+								Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+								ReplacePrefixMatch: ptrTo("bar"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name:     "invalid httpRoute with mix of filters and one duplicate",
+		errCount: 1,
+		rules: []gatewayv1.HTTPRouteRule{
+			{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptrTo(gatewayv1.PathMatchType("PathPrefix")),
+							Value: ptrTo("/"),
+						},
+					},
+				},
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{
+								{
+									Name:  "special-header",
+									Value: "foo",
+								},
+							},
+						},
+					},
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1.BackendObjectReference{
+								Name: testService,
+								Port: ptrTo(gatewayv1.PortNumber(8080)),
+							},
+						},
+					},
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Add: []gatewayv1.HTTPHeader{
+								{
+									Name:  "my-header",
+									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name:     "invalid httpRoute with multiple duplicate filters",
+		errCount: 2,
+		rules: []gatewayv1.HTTPRouteRule{
+			{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptrTo(gatewayv1.PathMatchType("PathPrefix")),
+							Value: ptrTo("/"),
+						},
+					},
+				},
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{
+								{
+									Name:  "special-header",
+									Value: "foo",
+								},
+							},
+						},
+					},
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Add: []gatewayv1.HTTPHeader{
+								{
+									Name:  "my-header",
+									Value: "bar",
+								},
+							},
+						},
+					},
+					{
+						Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+						ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Add: []gatewayv1.HTTPHeader{
+								{
+									Name:  "extra-header",
+									Value: "foo",
+								},
+							},
+						},
+					},
+					{
+						Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+						ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{
+								{
+									Name:  "other-header",
+									Value: "bat",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name:     "valid httpRoute with duplicate ExtensionRef filters",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{
+			{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptrTo(gatewayv1.PathMatchType("PathPrefix")),
+							Value: ptrTo("/"),
+						},
+					},
+				},
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{
+								{
+									Name:  "special-header",
+									Value: "foo",
+								},
+							},
+						},
+					},
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1.BackendObjectReference{
+								Name: testService,
+								Port: ptrTo(gatewayv1.PortNumber(8080)),
+							},
+						},
+					},
+					{
+						Type: "ExtensionRef",
+						ExtensionRef: &gatewayv1.LocalObjectReference{
+							Kind: "Service",
+							Name: "test",
+						},
+					},
+					{
+						Type: "ExtensionRef",
+						ExtensionRef: &gatewayv1.LocalObjectReference{
+							Kind: "Service",
+							Name: "test",
+						},
+					},
+					{
+						Type: "ExtensionRef",
+						ExtensionRef: &gatewayv1.LocalObjectReference{
+							Kind: "Service",
+							Name: "test",
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name:     "valid redirect path modifier",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{
+			{
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+						RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+							Path: &gatewayv1.HTTPPathModifier{
+								Type:            gatewayv1.FullPathHTTPPathModifier,
+								ReplaceFullPath: ptrTo("foo"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name:     "redirect path modifier with type mismatch",
+		errCount: 2,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+					Path: &gatewayv1.HTTPPathModifier{
+						Type:            gatewayv1.PrefixMatchHTTPPathModifier,
+						ReplaceFullPath: ptrTo("foo"),
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "valid rewrite path modifier",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Matches: []gatewayv1.HTTPRouteMatch{{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  &pathPrefixMatchType,
+					Value: ptrTo("/bar"),
+				},
+			}},
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterURLRewrite,
+				URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+					Path: &gatewayv1.HTTPPathModifier{
+						Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+						ReplacePrefixMatch: ptrTo("foo"),
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "rewrite path modifier missing path match",
+		errCount: 1,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterURLRewrite,
+				URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+					Path: &gatewayv1.HTTPPathModifier{
+						Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+						ReplacePrefixMatch: ptrTo("foo"),
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "rewrite path too many matches",
+		errCount: 1,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Matches: []gatewayv1.HTTPRouteMatch{{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  &pathPrefixMatchType,
+					Value: ptrTo("/foo"),
+				},
+			}, {
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  &pathPrefixMatchType,
+					Value: ptrTo("/bar"),
+				},
+			}},
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterURLRewrite,
+				URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+					Path: &gatewayv1.HTTPPathModifier{
+						Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+						ReplacePrefixMatch: ptrTo("foo"),
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "redirect path modifier with type mismatch",
+		errCount: 2,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterURLRewrite,
+				URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+					Path: &gatewayv1.HTTPPathModifier{
+						Type:               gatewayv1.FullPathHTTPPathModifier,
+						ReplacePrefixMatch: ptrTo("foo"),
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "rewrite and redirect filters combined (invalid)",
+		errCount: 3,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterURLRewrite,
+				URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+					Path: &gatewayv1.HTTPPathModifier{
+						Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+						ReplacePrefixMatch: ptrTo("foo"),
+					},
+				},
+			}, {
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+					Path: &gatewayv1.HTTPPathModifier{
+						Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+						ReplacePrefixMatch: ptrTo("foo"),
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple actions for the same request header (invalid)",
+		errCount: 2,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-fruit"),
+							Value: "apple",
+						},
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-vegetable"),
+							Value: "carrot",
+						},
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-grain"),
+							Value: "rye",
+						},
+					},
+					Set: []gatewayv1.HTTPHeader{
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-fruit"),
+							Value: "watermelon",
+						},
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-grain"),
+							Value: "wheat",
+						},
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-spice"),
+							Value: "coriander",
+						},
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple actions for the same request header with inconsistent case (invalid)",
+		errCount: 1,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-fruit"),
+							Value: "apple",
+						},
+					},
+					Set: []gatewayv1.HTTPHeader{
+						{
+							Name:  gatewayv1.HTTPHeaderName("X-Fruit"),
+							Value: "watermelon",
+						},
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple of the same action for the same request header (invalid)",
+		errCount: 1,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-fruit"),
+							Value: "apple",
+						},
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-fruit"),
+							Value: "plum",
+						},
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple actions for different request headers",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-vegetable"),
+							Value: "carrot",
+						},
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-grain"),
+							Value: "rye",
+						},
+					},
+					Set: []gatewayv1.HTTPHeader{
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-fruit"),
+							Value: "watermelon",
+						},
+						{
+							Name:  gatewayv1.HTTPHeaderName("x-spice"),
+							Value: "coriander",
+						},
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple actions for the same response header (invalid)",
+		errCount: 1,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{{
+						Name:  gatewayv1.HTTPHeaderName("x-example"),
+						Value: "blueberry",
+					}},
+					Set: []gatewayv1.HTTPHeader{{
+						Name:  gatewayv1.HTTPHeaderName("x-example"),
+						Value: "turnip",
+					}},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple actions for different response headers",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{{
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{{
+						Name:  gatewayv1.HTTPHeaderName("x-example"),
+						Value: "blueberry",
+					}},
+					Set: []gatewayv1.HTTPHeader{{
+						Name:  gatewayv1.HTTPHeaderName("x-different"),
+						Value: "turnip",
+					}},
+				},
+			}},
+		}},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var errs field.ErrorList
+			route := gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: tc.rules}}
+			errs = ValidateHTTPRoute(&route)
+			if len(errs) != tc.errCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPBackendUniqueFilters(t *testing.T) {
+	var testService gatewayv1.ObjectName = "testService"
+	var specialService gatewayv1.ObjectName = "specialService"
+	tests := []struct {
+		name     string
+		rules    []gatewayv1.HTTPRouteRule
+		errCount int
+	}{{
+		name:     "valid httpRoute Rules backendref filters",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{{
+			BackendRefs: []gatewayv1.HTTPBackendRef{
+				{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: testService,
+							Port: ptrTo(gatewayv1.PortNumber(8080)),
+						},
+						Weight: ptrTo(int32(100)),
+					},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name: testService,
+									Port: ptrTo(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+	}, {
+		name:     "valid httpRoute Rules duplicate mirror filter",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{{
+			BackendRefs: []gatewayv1.HTTPBackendRef{
+				{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: testService,
+							Port: ptrTo(gatewayv1.PortNumber(8080)),
+						},
+					},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name: testService,
+									Port: ptrTo(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+						{
+							Type: gatewayv1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name: specialService,
+									Port: ptrTo(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: tc.rules}}
+			errs := ValidateHTTPRoute(&route)
+			if len(errs) != tc.errCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPPathMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     *gatewayv1.HTTPPathMatch
+		errCount int
+	}{{
+		name: "invalid httpRoute prefix (/.)",
+		path: &gatewayv1.HTTPPathMatch{
+			Type:  ptrTo(gatewayv1.PathMatchType("PathPrefix")),
+			Value: ptrTo("/."),
+		},
+		errCount: 1,
+	}, {
+		name: "invalid exact (/./)",
+		path: &gatewayv1.HTTPPathMatch{
+			Type:  ptrTo(gatewayv1.PathMatchType("Exact")),
+			Value: ptrTo("/foo/./bar"),
+		},
+		errCount: 1,
+	}, {
+		name: "valid httpRoute prefix",
+		path: &gatewayv1.HTTPPathMatch{
+			Type:  ptrTo(gatewayv1.PathMatchType("PathPrefix")),
+			Value: ptrTo("/"),
+		},
+		errCount: 0,
+	}, {
+		name: "invalid httpRoute prefix (/[])",
+		path: &gatewayv1.HTTPPathMatch{
+			Type:  ptrTo(gatewayv1.PathMatchType("PathPrefix")),
+			Value: ptrTo("/[]"),
+		},
+		errCount: 1,
+	}, {
+		name: "invalid httpRoute exact (/^)",
+		path: &gatewayv1.HTTPPathMatch{
+			Type:  ptrTo(gatewayv1.PathMatchType("Exact")),
+			Value: ptrTo("/^"),
+		},
+		errCount: 1,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{
+				Rules: []gatewayv1.HTTPRouteRule{{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: tc.path,
+					}},
+					BackendRefs: []gatewayv1.HTTPBackendRef{{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: gatewayv1.ObjectName("test"),
+								Port: ptrTo(gatewayv1.PortNumber(8080)),
+							},
+						},
+					}},
+				}},
+			}}
+
+			errs := ValidateHTTPRoute(&route)
+			if len(errs) != tc.errCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPHeaderMatches(t *testing.T) {
+	tests := []struct {
+		name          string
+		headerMatches []gatewayv1.HTTPHeaderMatch
+		expectErr     string
+	}{{
+		name:          "no header matches",
+		headerMatches: nil,
+		expectErr:     "",
+	}, {
+		name: "no header matched more than once",
+		headerMatches: []gatewayv1.HTTPHeaderMatch{
+			{Name: "Header-Name-1", Value: "val-1"},
+			{Name: "Header-Name-2", Value: "val-2"},
+			{Name: "Header-Name-3", Value: "val-3"},
+		},
+		expectErr: "",
+	}, {
+		name: "header matched more than once (same case)",
+		headerMatches: []gatewayv1.HTTPHeaderMatch{
+			{Name: "Header-Name-1", Value: "val-1"},
+			{Name: "Header-Name-2", Value: "val-2"},
+			{Name: "Header-Name-1", Value: "val-3"},
+		},
+		expectErr: "spec.rules[0].matches[0].headers: Invalid value: \"Header-Name-1\": cannot match the same header multiple times in the same rule",
+	}, {
+		name: "header matched more than once (different case)",
+		headerMatches: []gatewayv1.HTTPHeaderMatch{
+			{Name: "Header-Name-1", Value: "val-1"},
+			{Name: "Header-Name-2", Value: "val-2"},
+			{Name: "HEADER-NAME-2", Value: "val-3"},
+		},
+		expectErr: "spec.rules[0].matches[0].headers: Invalid value: \"Header-Name-2\": cannot match the same header multiple times in the same rule",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{
+				Rules: []gatewayv1.HTTPRouteRule{{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: tc.headerMatches,
+					}},
+					BackendRefs: []gatewayv1.HTTPBackendRef{{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: gatewayv1.ObjectName("test"),
+								Port: ptrTo(gatewayv1.PortNumber(8080)),
+							},
+						},
+					}},
+				}},
+			}}
+
+			errs := ValidateHTTPRoute(&route)
+			if len(tc.expectErr) == 0 {
+				assert.Emptyf(t, errs, "expected no errors, got %d errors: %s", len(errs), errs)
+			} else {
+				require.Lenf(t, errs, 1, "expected one error, got %d errors: %s", len(errs), errs)
+				assert.Equal(t, tc.expectErr, errs[0].Error())
+			}
+		})
+	}
+}
+
+func TestValidateHTTPQueryParamMatches(t *testing.T) {
+	tests := []struct {
+		name              string
+		queryParamMatches []gatewayv1.HTTPQueryParamMatch
+		expectErr         string
+	}{{
+		name:              "no query param matches",
+		queryParamMatches: nil,
+		expectErr:         "",
+	}, {
+		name: "no query param matched more than once",
+		queryParamMatches: []gatewayv1.HTTPQueryParamMatch{
+			{Name: "query-param-1", Value: "val-1"},
+			{Name: "query-param-2", Value: "val-2"},
+			{Name: "query-param-3", Value: "val-3"},
+		},
+		expectErr: "",
+	}, {
+		name: "query param matched more than once",
+		queryParamMatches: []gatewayv1.HTTPQueryParamMatch{
+			{Name: "query-param-1", Value: "val-1"},
+			{Name: "query-param-2", Value: "val-2"},
+			{Name: "query-param-1", Value: "val-3"},
+		},
+		expectErr: "spec.rules[0].matches[0].queryParams: Invalid value: \"query-param-1\": cannot match the same query parameter multiple times in the same rule",
+	}, {
+		name: "query param names with different casing are not considered duplicates",
+		queryParamMatches: []gatewayv1.HTTPQueryParamMatch{
+			{Name: "query-param-1", Value: "val-1"},
+			{Name: "query-param-2", Value: "val-2"},
+			{Name: "QUERY-PARAM-1", Value: "val-3"},
+		},
+		expectErr: "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{
+				Rules: []gatewayv1.HTTPRouteRule{{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						QueryParams: tc.queryParamMatches,
+					}},
+					BackendRefs: []gatewayv1.HTTPBackendRef{{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: gatewayv1.ObjectName("test"),
+								Port: ptrTo(gatewayv1.PortNumber(8080)),
+							},
+						},
+					}},
+				}},
+			}}
+
+			errs := ValidateHTTPRoute(&route)
+			if len(tc.expectErr) == 0 {
+				assert.Emptyf(t, errs, "expected no errors, got %d errors: %s", len(errs), errs)
+			} else {
+				require.Lenf(t, errs, 1, "expected one error, got %d errors: %s", len(errs), errs)
+				assert.Equal(t, tc.expectErr, errs[0].Error())
+			}
+		})
+	}
+}
+
+func TestValidateServicePort(t *testing.T) {
+	portPtr := func(n int) *gatewayv1.PortNumber {
+		p := gatewayv1.PortNumber(n)
+		return &p
+	}
+
+	groupPtr := func(g string) *gatewayv1.Group {
+		p := gatewayv1.Group(g)
+		return &p
+	}
+
+	kindPtr := func(k string) *gatewayv1.Kind {
+		p := gatewayv1.Kind(k)
+		return &p
+	}
+
+	tests := []struct {
+		name     string
+		rules    []gatewayv1.HTTPRouteRule
+		errCount int
+	}{{
+		name:     "default groupkind with port",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{{
+			BackendRefs: []gatewayv1.HTTPBackendRef{{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "backend",
+						Port: portPtr(99),
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "default groupkind with no port",
+		errCount: 1,
+		rules: []gatewayv1.HTTPRouteRule{{
+			BackendRefs: []gatewayv1.HTTPBackendRef{{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "backend",
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "explicit service with port",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{{
+			BackendRefs: []gatewayv1.HTTPBackendRef{{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Group: groupPtr(""),
+						Kind:  kindPtr("Service"),
+						Name:  "backend",
+						Port:  portPtr(99),
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "explicit service with no port",
+		errCount: 1,
+		rules: []gatewayv1.HTTPRouteRule{{
+			BackendRefs: []gatewayv1.HTTPBackendRef{{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Group: groupPtr(""),
+						Kind:  kindPtr("Service"),
+						Name:  "backend",
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "explicit ref with no port",
+		errCount: 0,
+		rules: []gatewayv1.HTTPRouteRule{{
+			BackendRefs: []gatewayv1.HTTPBackendRef{{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Group: groupPtr("foo.example.com"),
+						Kind:  kindPtr("Foo"),
+						Name:  "backend",
+					},
+				},
+			}},
+		}},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: tc.rules}}
+			errs := ValidateHTTPRoute(&route)
+			if len(errs) != tc.errCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
+	tests := []struct {
+		name        string
+		routeFilter gatewayv1.HTTPRouteFilter
+		errCount    int
+	}{{
+		name: "valid HTTPRouteFilterRequestHeaderModifier route filter",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+			RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+				Set:    []gatewayv1.HTTPHeader{{Name: "name"}},
+				Add:    []gatewayv1.HTTPHeader{{Name: "add"}},
+				Remove: []string{"remove"},
+			},
+		},
+		errCount: 0,
+	}, {
+		name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with non-matching field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type:          gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+			RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{},
+		},
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with empty value field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+		},
+		errCount: 1,
+	}, {
+		name: "valid HTTPRouteFilterRequestMirror route filter",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterRequestMirror,
+			RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{BackendRef: gatewayv1.BackendObjectReference{
+				Group:     new(gatewayv1.Group),
+				Kind:      new(gatewayv1.Kind),
+				Name:      "name",
+				Namespace: new(gatewayv1.Namespace),
+				Port:      ptrTo(gatewayv1.PortNumber(22)),
+			}},
+		},
+		errCount: 0,
+	}, {
+		name: "invalid HTTPRouteFilterRequestMirror type filter with non-matching field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type:                  gatewayv1.HTTPRouteFilterRequestMirror,
+			RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{},
+		},
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterRequestMirror type filter with empty value field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterRequestMirror,
+		},
+		errCount: 1,
+	}, {
+		name: "valid HTTPRouteFilterRequestRedirect route filter",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+			RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+				Scheme:     new(string),
+				Hostname:   new(gatewayv1.PreciseHostname),
+				Path:       &gatewayv1.HTTPPathModifier{},
+				Port:       new(gatewayv1.PortNumber),
+				StatusCode: new(int),
+			},
+		},
+		errCount: 1,
+	}, {
+		name: "invalid HTTPRouteFilterRequestRedirect type filter with non-matching field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type:          gatewayv1.HTTPRouteFilterRequestRedirect,
+			RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{},
+		},
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterRequestRedirect type filter with empty value field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+		},
+		errCount: 1,
+	}, {
+		name: "valid HTTPRouteFilterExtensionRef filter",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterExtensionRef,
+			ExtensionRef: &gatewayv1.LocalObjectReference{
+				Group: "group",
+				Kind:  "kind",
+				Name:  "name",
+			},
+		},
+		errCount: 0,
+	}, {
+		name: "invalid HTTPRouteFilterExtensionRef type filter with non-matching field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type:          gatewayv1.HTTPRouteFilterExtensionRef,
+			RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{},
+		},
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterExtensionRef type filter with empty value field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterExtensionRef,
+		},
+		errCount: 1,
+	}, {
+		name: "valid HTTPRouteFilterURLRewrite route filter",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterURLRewrite,
+			URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+				Hostname: new(gatewayv1.PreciseHostname),
+				Path:     &gatewayv1.HTTPPathModifier{},
+			},
+		},
+		errCount: 0,
+	}, {
+		name: "invalid HTTPRouteFilterURLRewrite type filter with non-matching field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type:          gatewayv1.HTTPRouteFilterURLRewrite,
+			RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{},
+		},
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterURLRewrite type filter with empty value field",
+		routeFilter: gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterURLRewrite,
+		},
+		errCount: 1,
+	}, {
+		name:        "empty type filter is valid (caught by CRD validation)",
+		routeFilter: gatewayv1.HTTPRouteFilter{},
+		errCount:    0,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := gatewayv1.HTTPRoute{
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{{
+						Filters: []gatewayv1.HTTPRouteFilter{tc.routeFilter},
+						BackendRefs: []gatewayv1.HTTPBackendRef{{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName("test"),
+									Port: ptrTo(gatewayv1.PortNumber(8080)),
+								},
+							},
+						}},
+					}},
+				},
+			}
+			errs := ValidateHTTPRoute(&route)
+			if len(errs) != tc.errCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}
+
+func TestValidateRequestRedirectFiltersWithNoBackendRef(t *testing.T) {
+	testService := gatewayv1.ObjectName("test-service")
+	tests := []struct {
+		name     string
+		rules    []gatewayv1.HTTPRouteRule
+		errCount int
+	}{
+		{
+			name:     "backendref with request redirect httpRoute filter",
+			errCount: 1,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+							RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+								Scheme:     ptrTo("https"),
+								StatusCode: ptrTo(301),
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: testService,
+									Port: ptrTo(gatewayv1.PortNumber(80)),
+								},
+							},
+						},
+					},
+				},
+			},
+		}, {
+			name:     "request redirect without backendref in httpRoute filter",
+			errCount: 0,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+							RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+								Scheme:     ptrTo("https"),
+								StatusCode: ptrTo(301),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var errs field.ErrorList
+			route := gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: tc.rules}}
+			errs = ValidateHTTPRoute(&route)
+			if len(errs) != tc.errCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}
+
+func toDuration(durationString string) *gatewayv1.Duration {
+	return (*gatewayv1.Duration)(&durationString)
+}
+
+func TestValidateHTTPTimeouts(t *testing.T) {
+	tests := []struct {
+		name     string
+		rules    []gatewayv1.HTTPRouteRule
+		errCount int
+	}{
+		{
+			name:     "valid httpRoute Rules timeouts",
+			errCount: 0,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request: toDuration("1ms"),
+					},
+				},
+			},
+		}, {
+			name:     "valid httpRoute Rules timeout set to 0s (disabled)",
+			errCount: 0,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request: toDuration("0s"),
+					},
+				},
+			},
+		}, {
+			name:     "valid httpRoute Rules timeout set to 0ms (disabled)",
+			errCount: 0,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request: toDuration("0ms"),
+					},
+				},
+			},
+		}, {}, {
+			name:     "valid httpRoute Rules timeout set to 0h (disabled)",
+			errCount: 0,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request: toDuration("0h"),
+					},
+				},
+			},
+		}, {
+			name:     "valid httpRoute Rules timeout and backendRequest have the same value",
+			errCount: 0,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request:        toDuration("1ms"),
+						BackendRequest: toDuration("1ms"),
+					},
+				},
+			},
+		}, {
+			name:     "invalid httpRoute Rules backendRequest timeout cannot be longer than request timeout",
+			errCount: 1,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request:        toDuration("1ms"),
+						BackendRequest: toDuration("2ms"),
+					},
+				},
+			},
+		}, {
+			name:     "valid httpRoute Rules request timeout 1s and backendRequest timeout 200ms",
+			errCount: 0,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request:        toDuration("1s"),
+						BackendRequest: toDuration("200ms"),
+					},
+				},
+			},
+		}, {
+			name:     "valid httpRoute Rules request timeout 10s and backendRequest timeout 10s",
+			errCount: 0,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request:        toDuration("10s"),
+						BackendRequest: toDuration("10s"),
+					},
+				},
+			},
+		}, {
+			name:     "invalid httpRoute Rules backendRequest timeout cannot be greater than request timeout",
+			errCount: 1,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request:        toDuration("200ms"),
+						BackendRequest: toDuration("1s"),
+					},
+				},
+			},
+		}, {
+			name:     "valid httpRoute Rules request 0s (infinite) and backendRequest 100ms",
+			errCount: 0,
+			rules: []gatewayv1.HTTPRouteRule{
+				{
+					Timeouts: &gatewayv1.HTTPRouteTimeouts{
+						Request:        toDuration("0s"),
+						BackendRequest: toDuration("100ms"),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: tc.rules}}
+			errs := ValidateHTTPRoute(&route)
+			if len(errs) != tc.errCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1alpha2/util/validation/gatewayclass.go
+++ b/pkg/apis/gateway/v1alpha2/util/validation/gatewayclass.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	validationutilv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1/util/validation"
+)
+
+// IsControllerNameValid checks that the provided controllerName complies with the expected
+// format. It must be a non-empty domain prefixed path.
+var IsControllerNameValid = validationutilv1beta1.IsControllerNameValid

--- a/pkg/apis/gateway/v1alpha2/validation/common.go
+++ b/pkg/apis/gateway/v1alpha2/validation/common.go
@@ -19,8 +19,9 @@ package validation
 import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	gatewayvalidationv1b1 "github.com/flomesh-io/fsm/pkg/apis/gateway/v1beta1/validation"
 	v1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	gatewayvalidationv1b1 "github.com/flomesh-io/fsm/pkg/apis/gateway/v1beta1/validation"
 )
 
 // validateParentRefs validates ParentRefs SectionName must be set and unique
@@ -46,8 +47,4 @@ func validateBackendRefServicePort(ref *v1a2.BackendRef, path *field.Path) field
 	}
 
 	return errs
-}
-
-func ptrTo[T any](a T) *T {
-	return &a
 }

--- a/pkg/apis/gateway/v1alpha2/validation/common.go
+++ b/pkg/apis/gateway/v1alpha2/validation/common.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayvalidationv1b1 "github.com/flomesh-io/fsm/pkg/apis/gateway/v1beta1/validation"
+	v1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// validateParentRefs validates ParentRefs SectionName must be set and unique
+// when ParentRefs includes 2 or more references to the same parent
+var validateParentRefs = gatewayvalidationv1b1.ValidateParentRefs
+
+// validateBackendRefServicePort validates whether or not a port was specified
+// for a backendRef which refers to a corev1.Service, asserting that the port
+// field is required.
+func validateBackendRefServicePort(ref *v1a2.BackendRef, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+
+	if ref.Group != nil && *ref.Group != "" {
+		return nil
+	}
+
+	if ref.Kind != nil && *ref.Kind != "Service" {
+		return nil
+	}
+
+	if ref.Port == nil {
+		errs = append(errs, field.Required(path.Child("port"), "missing port for Service reference"))
+	}
+
+	return errs
+}
+
+func ptrTo[T any](a T) *T {
+	return &a
+}

--- a/pkg/apis/gateway/v1alpha2/validation/doc.go
+++ b/pkg/apis/gateway/v1alpha2/validation/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package validation has functions for validating the correctness of api
+// objects and explaining what's wrong with them when they're not valid.
+package validation // import "github.com/flomesh-io/fsm/pkg/apis/gateway/v1alpha2/validation"

--- a/pkg/apis/gateway/v1alpha2/validation/tcproute.go
+++ b/pkg/apis/gateway/v1alpha2/validation/tcproute.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// ValidateTCPRoute validates TCPRoute according to the Gateway API specification.
+// For additional details of the TCPRoute spec, refer to:
+// https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
+func ValidateTCPRoute(route *gatewayv1a2.TCPRoute) field.ErrorList {
+	return validateTCPRouteSpec(&route.Spec, field.NewPath("spec"))
+}
+
+// validateTCPRouteSpec validates that required fields of spec are set according to the
+// TCPRoute specification.
+func validateTCPRouteSpec(spec *gatewayv1a2.TCPRouteSpec, path *field.Path) field.ErrorList {
+	path = path.Child("rules")
+	var errs field.ErrorList
+	for i, rule := range spec.Rules {
+		for j, ref := range rule.BackendRefs {
+			// Avoid referencing to the loop variable.
+			ref := ref
+			errs = append(errs, validateBackendRefServicePort(&ref, path.Index(i).Child("backendRefs").Index(j))...)
+			errs = append(errs, validateParentRefs(spec.ParentRefs, path.Child("spec"))...)
+		}
+	}
+	return errs
+}

--- a/pkg/apis/gateway/v1alpha2/validation/tcproute_test.go
+++ b/pkg/apis/gateway/v1alpha2/validation/tcproute_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestValidateTCPRoute(t *testing.T) {
+	t.Parallel()
+
+	portNumber := gatewayv1a2.PortNumber(9080)
+
+	tests := []struct {
+		name  string
+		rules []gatewayv1a2.TCPRouteRule
+		errs  field.ErrorList
+	}{
+		{
+			name: "valid TCPRoute with 1 backendRef",
+			rules: []gatewayv1a2.TCPRouteRule{
+				{
+					BackendRefs: []gatewayv1a2.BackendRef{
+						{
+							BackendObjectReference: gatewayv1a2.BackendObjectReference{
+								Port: &portNumber,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid TCPRoute with 1 backendRef (missing port)",
+			rules: []gatewayv1a2.TCPRouteRule{
+				{
+					BackendRefs: []gatewayv1a2.BackendRef{
+						{
+							BackendObjectReference: gatewayv1a2.BackendObjectReference{
+								Port: nil,
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{
+				{
+					Type:   field.ErrorTypeRequired,
+					Field:  "spec.rules[0].backendRefs[0].port",
+					Detail: "missing port for Service reference",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			route := gatewayv1a2.TCPRoute{Spec: gatewayv1a2.TCPRouteSpec{Rules: tc.rules}}
+			errs := ValidateTCPRoute(&route)
+			if len(errs) != len(tc.errs) {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), len(tc.errs), errs)
+				t.FailNow()
+			}
+			for i := 0; i < len(errs); i++ {
+				realErr := errs[i].Error()
+				expectedErr := tc.errs[i].Error()
+				if realErr != expectedErr {
+					t.Errorf("expect error message: %s, but got: %s", expectedErr, realErr)
+					t.FailNow()
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1alpha2/validation/tlsroute.go
+++ b/pkg/apis/gateway/v1alpha2/validation/tlsroute.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// ValidateTLSRoute validates TLSRoute according to the Gateway API specification.
+// For additional details of the TLSRoute spec, refer to:
+// https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.TLSRoute
+func ValidateTLSRoute(route *gatewayv1a2.TLSRoute) field.ErrorList {
+	return validateTLSRouteSpec(&route.Spec, field.NewPath("spec"))
+}
+
+// validateTLSRouteSpec validates that required fields of spec are set according to the
+// TLSRoute specification.
+func validateTLSRouteSpec(spec *gatewayv1a2.TLSRouteSpec, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	path = path.Child("rules")
+
+	for i, rule := range spec.Rules {
+		for j, ref := range rule.BackendRefs {
+			// Avoid referencing to the loop variable.
+			ref := ref
+			errs = append(errs, validateBackendRefServicePort(&ref, path.Index(i).Child("backendRefs").Index(j))...)
+			errs = append(errs, validateParentRefs(spec.ParentRefs, path.Child("spec"))...)
+		}
+	}
+	return errs
+}

--- a/pkg/apis/gateway/v1alpha2/validation/tlsroute_test.go
+++ b/pkg/apis/gateway/v1alpha2/validation/tlsroute_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestValidateTLSRoute(t *testing.T) {
+	t.Parallel()
+
+	var portNumber int32 = 9080
+
+	tests := []struct {
+		name  string
+		rules []gatewayv1a2.TLSRouteRule
+		errs  field.ErrorList
+	}{
+		{
+			name:  "valid TLSRoute with 1 backendRef",
+			rules: makeRouteRules[gatewayv1a2.TLSRouteRule](&portNumber),
+		},
+		{
+			name:  "invalid TLSRoute with 1 backendRef (missing port)",
+			rules: makeRouteRules[gatewayv1a2.TLSRouteRule](nil),
+			errs: field.ErrorList{
+				{
+					Type:   field.ErrorTypeRequired,
+					Field:  "spec.rules[0].backendRefs[0].port",
+					Detail: "missing port for Service reference",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			route := gatewayv1a2.TLSRoute{Spec: gatewayv1a2.TLSRouteSpec{Rules: tc.rules}}
+			errs := ValidateTLSRoute(&route)
+			if len(errs) != len(tc.errs) {
+				t.Fatalf("got %d errors, want %d errors: %s", len(errs), len(tc.errs), errs)
+			}
+			for i := 0; i < len(errs); i++ {
+				realErr := errs[i].Error()
+				expectedErr := tc.errs[i].Error()
+				if realErr != expectedErr {
+					t.Fatalf("expect error message: %s, but got: %s", expectedErr, realErr)
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1alpha2/validation/udproute.go
+++ b/pkg/apis/gateway/v1alpha2/validation/udproute.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// ValidateUDPRoute validates UDPRoute according to the Gateway API specification.
+// For additional details of the UDPRoute spec, refer to:
+// https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.UDPRoute
+func ValidateUDPRoute(route *gatewayv1a2.UDPRoute) field.ErrorList {
+	return validateUDPRouteSpec(&route.Spec, field.NewPath("spec"))
+}
+
+// validateUDPRouteSpec validates that required fields of spec are set according to the
+// UDPRoute specification.
+func validateUDPRouteSpec(spec *gatewayv1a2.UDPRouteSpec, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	path = path.Child("rules")
+
+	for i, rule := range spec.Rules {
+		for j, ref := range rule.BackendRefs {
+			// Avoid referencing to the loop variable.
+			ref := ref
+			errs = append(errs, validateBackendRefServicePort(&ref, path.Index(i).Child("backendRefs").Index(j))...)
+			errs = append(errs, validateParentRefs(spec.ParentRefs, path.Child("spec"))...)
+		}
+	}
+	return errs
+}

--- a/pkg/apis/gateway/v1alpha2/validation/udproute_test.go
+++ b/pkg/apis/gateway/v1alpha2/validation/udproute_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestValidateUDPRoute(t *testing.T) {
+	t.Parallel()
+
+	var portNumber int32 = 9080
+
+	tests := []struct {
+		name  string
+		rules []gatewayv1a2.UDPRouteRule
+		errs  field.ErrorList
+	}{
+		{
+			name:  "valid UDPRoute with 1 backendRef",
+			rules: makeRouteRules[gatewayv1a2.UDPRouteRule](&portNumber),
+		},
+		{
+			name:  "invalid UDPRoute with 1 backendRef (missing port)",
+			rules: makeRouteRules[gatewayv1a2.UDPRouteRule](nil),
+			errs: field.ErrorList{
+				{
+					Type:   field.ErrorTypeRequired,
+					Field:  "spec.rules[0].backendRefs[0].port",
+					Detail: "missing port for Service reference",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			route := gatewayv1a2.UDPRoute{Spec: gatewayv1a2.UDPRouteSpec{Rules: tc.rules}}
+			errs := ValidateUDPRoute(&route)
+			if len(errs) != len(tc.errs) {
+				t.Fatalf("got %d errors, want %d errors: %s", len(errs), len(tc.errs), errs)
+			}
+			for i := 0; i < len(errs); i++ {
+				realErr := errs[i].Error()
+				expectedErr := tc.errs[i].Error()
+				if realErr != expectedErr {
+					t.Fatalf("expect error message: %s, but got: %s", expectedErr, realErr)
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1alpha2/validation/utils_test.go
+++ b/pkg/apis/gateway/v1alpha2/validation/utils_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type routeRule interface {
+	gatewayv1a2.TLSRouteRule | gatewayv1a2.UDPRouteRule
+}
+
+func makeRouteRules[T routeRule](ports ...*int32) (rules []T) {
+	for _, port := range ports {
+		rules = append(rules, T{
+			BackendRefs: []gatewayv1a2.BackendRef{{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Port: (*v1beta1.PortNumber)(port),
+				},
+			}},
+		})
+	}
+	return
+}

--- a/pkg/apis/gateway/v1beta1/util/validation/gatewayclass.go
+++ b/pkg/apis/gateway/v1beta1/util/validation/gatewayclass.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"regexp"
+
+	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+var controllerNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`)
+
+// IsControllerNameValid checks that the provided controllerName complies with the expected
+// format. It must be a non-empty domain prefixed path.
+func IsControllerNameValid(controllerName gatewayv1b1.GatewayController) bool {
+	if controllerName == "" {
+		return false
+	}
+	return controllerNameRegex.Match([]byte(controllerName))
+}

--- a/pkg/apis/gateway/v1beta1/util/validation/gatewayclass_test.go
+++ b/pkg/apis/gateway/v1beta1/util/validation/gatewayclass_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation_test
+
+import (
+	"testing"
+
+	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	validationtutils "sigs.k8s.io/gateway-api/apis/v1beta1/util/validation"
+)
+
+func TestIsControllerNameValid(t *testing.T) {
+	testCases := []struct {
+		name           string
+		controllerName gatewayv1b1.GatewayController
+		isvalid        bool
+	}{
+		{
+			name:           "empty controller name",
+			controllerName: "",
+			isvalid:        false,
+		},
+		{
+			name:           "invalid controller name 1",
+			controllerName: "example.com",
+			isvalid:        false,
+		},
+		{
+			name:           "invalid controller name 2",
+			controllerName: "example*com/bar",
+			isvalid:        false,
+		},
+		{
+			name:           "invalid controller name 3",
+			controllerName: "example/@bar",
+			isvalid:        false,
+		},
+		{
+			name:           "valid controller name",
+			controllerName: "example.com/bar",
+			isvalid:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			isValid := validationtutils.IsControllerNameValid(tc.controllerName)
+			if isValid != tc.isvalid {
+				t.Errorf("Expected validity %t, got %t", tc.isvalid, isValid)
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1beta1/validation/common.go
+++ b/pkg/apis/gateway/v1beta1/validation/common.go
@@ -80,7 +80,3 @@ func ValidateParentRefs(parentRefs []gatewayv1b1.ParentReference, path *field.Pa
 	}
 	return errs
 }
-
-func ptrTo[T any](a T) *T {
-	return &a
-}

--- a/pkg/apis/gateway/v1beta1/validation/common.go
+++ b/pkg/apis/gateway/v1beta1/validation/common.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// ValidateParentRefs validates ParentRefs SectionName must be set and unique
+// when ParentRefs includes 2 or more references to the same parent
+func ValidateParentRefs(parentRefs []gatewayv1b1.ParentReference, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if len(parentRefs) <= 1 {
+		return nil
+	}
+	type sameKindParentRefs struct {
+		name      gatewayv1b1.ObjectName
+		namespace gatewayv1b1.Namespace
+		kind      gatewayv1b1.Kind
+	}
+	type parentQualifier struct {
+		section gatewayv1b1.SectionName
+		port    gatewayv1b1.PortNumber
+	}
+	parentRefsSectionMap := make(map[sameKindParentRefs]sets.Set[parentQualifier])
+	for i, p := range parentRefs {
+		targetParentRefs := sameKindParentRefs{name: p.Name, namespace: gatewayv1b1.Namespace(""), kind: gatewayv1b1.Kind("")}
+		pq := parentQualifier{}
+		if p.Namespace != nil {
+			targetParentRefs.namespace = *p.Namespace
+		}
+		if p.Kind != nil {
+			targetParentRefs.kind = *p.Kind
+		}
+		if p.SectionName != nil {
+			pq.section = *p.SectionName
+		}
+		if p.Port != nil {
+			pq.port = *p.Port
+		}
+		if s, ok := parentRefsSectionMap[targetParentRefs]; ok {
+			if s.UnsortedList()[0] == (parentQualifier{}) || pq == (parentQualifier{}) {
+				errs = append(errs, field.Required(path.Child("parentRefs"), "sectionNames or ports must be specified when more than one parentRef refers to the same parent"))
+				return errs
+			}
+			if s.Has(pq) {
+				fieldPath := path.Index(i).Child("parentRefs")
+				var val any
+				if len(pq.section) > 0 {
+					fieldPath = fieldPath.Child("sectionName")
+					val = pq.section
+				} else {
+					fieldPath = fieldPath.Child("port")
+					val = pq.port
+				}
+				errs = append(errs, field.Invalid(fieldPath, val, "must be unique when ParentRefs includes 2 or more references to the same parent"))
+				return errs
+			}
+			parentRefsSectionMap[targetParentRefs].Insert(pq)
+		} else {
+			parentRefsSectionMap[targetParentRefs] = sets.New(pq)
+		}
+	}
+	return errs
+}
+
+func ptrTo[T any](a T) *T {
+	return &a
+}

--- a/pkg/apis/gateway/v1beta1/validation/common.go
+++ b/pkg/apis/gateway/v1beta1/validation/common.go
@@ -80,3 +80,8 @@ func ValidateParentRefs(parentRefs []gatewayv1b1.ParentReference, path *field.Pa
 	}
 	return errs
 }
+
+//lint:ignore U1000 ignore unused
+func ptrTo[T any](a T) *T {
+	return &a
+}

--- a/pkg/apis/gateway/v1beta1/validation/common_test.go
+++ b/pkg/apis/gateway/v1beta1/validation/common_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+var path = field.Path{}
+
+func TestValidateParentRefs(t *testing.T) {
+	namespace := gatewayv1b1.Namespace("example-namespace")
+	kind := gatewayv1b1.Kind("Gateway")
+	sectionA := gatewayv1b1.SectionName("Section A")
+	sectionB := gatewayv1b1.SectionName("Section B")
+	sectionC := gatewayv1b1.SectionName("Section C")
+
+	tests := []struct {
+		name       string
+		parentRefs []gatewayv1b1.ParentReference
+		err        string
+	}{{
+		name: "valid ParentRefs includes 1 reference",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+		},
+		err: "",
+	}, {
+		name: "valid ParentRefs includes 2 references",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionB,
+			},
+		},
+		err: "",
+	}, {
+		name: "valid ParentRefs when different references have the same section name",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:        "example A",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example B",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+		},
+		err: "",
+	}, {
+		name: "valid ParentRefs includes more references to the same parent",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionB,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionC,
+			},
+		},
+		err: "",
+	}, {
+		name: "invalid ParentRefs due to the same section names to the same parentRefs",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Kind:        &kind,
+				SectionName: &sectionA,
+			},
+		},
+		err: "must be unique when ParentRefs",
+	}, {
+		name: "invalid ParentRefs due to section names not set to the same ParentRefs",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name: "example",
+			},
+			{
+				Name: "example",
+			},
+		},
+		err: "sectionNames or ports must be specified",
+	}, {
+		name: "invalid ParentRefs due to more same section names to the same ParentRefs",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: nil,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionB,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+		},
+		err: "sectionNames or ports must be specified",
+	}, {
+		name: "invalid ParentRefs when one ParentRef section name not set to the same ParentRefs",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: nil,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+		},
+		err: "sectionNames or ports must be specified",
+	}, {
+		name: "invalid ParentRefs when next ParentRef section name not set to the same ParentRefs",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: nil,
+			},
+		},
+		err: "sectionNames or ports must be specified",
+	}, {
+		name: "valid ParentRefs with multiple port references to the same parent",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1b1.PortNumber(80)),
+			},
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1b1.PortNumber(81)),
+			},
+		},
+		err: "",
+	}, {
+		name: "valid ParentRefs with multiple mixed references to the same parent",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1b1.PortNumber(80)),
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				SectionName: &sectionA,
+			},
+		},
+		err: "",
+	}, {
+		name: "invalid ParentRefs due to same port references to the same parent",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1b1.PortNumber(80)),
+			},
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1b1.PortNumber(80)),
+			},
+		},
+		err: "port: Invalid value: 80: must be unique when ParentRefs",
+	}, {
+		name: "invalid ParentRefs due to mixed port references to the same parent",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      ptrTo(gatewayv1b1.PortNumber(80)),
+			},
+			{
+				Name:      "example",
+				Namespace: &namespace,
+				Port:      nil,
+			},
+		},
+		err: "Required value: sectionNames or ports must be specified",
+	}, {
+		name: "valid ParentRefs with multiple same port references to different section of a  parent",
+		parentRefs: []gatewayv1b1.ParentReference{
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Port:        ptrTo(gatewayv1b1.PortNumber(80)),
+				SectionName: &sectionA,
+			},
+			{
+				Name:        "example",
+				Namespace:   &namespace,
+				Port:        ptrTo(gatewayv1b1.PortNumber(80)),
+				SectionName: &sectionB,
+			},
+		},
+		err: "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := gatewayv1b1.CommonRouteSpec{
+				ParentRefs: tc.parentRefs,
+			}
+			errs := ValidateParentRefs(spec.ParentRefs, path.Child("spec"))
+			if tc.err == "" {
+				if len(errs) != 0 {
+					t.Errorf("got %d errors, want none: %s", len(errs), errs)
+				}
+			} else {
+				if errs == nil {
+					t.Errorf("got no errors, want %q", tc.err)
+				} else if !strings.Contains(errs.ToAggregate().Error(), tc.err) {
+					t.Errorf("got %d errors, want %q: %s", len(errs), tc.err, errs)
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/gateway/v1beta1/validation/doc.go
+++ b/pkg/apis/gateway/v1beta1/validation/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package validation has functions for validating the correctness of api
+// objects and explaining what's wrong with them when they're not valid.
+package validation // import "github.com/flomesh-io/fsm/pkg/apis/gateway/v1beta1/validation"

--- a/pkg/version/utils.go
+++ b/pkg/version/utils.go
@@ -28,6 +28,12 @@ var (
 
 	// MinK8sVersionForGatewayAPI is the minimum version of Kubernetes that supports Gateway API.
 	MinK8sVersionForGatewayAPI = MinK8sVersion
+
+	// MinK8sVersionForCELValidation is the minimum version of Kubernetes that supports CustomResourceValidationExpressions.
+	// This feature was introduced since Kubernetes 1.23 but turned off by default.
+	// It has been turned on by default since Kubernetes 1.25 and finally graduated to GA in Kubernetes 1.29
+	// https://github.com/kubernetes/enhancements/issues/2876
+	MinK8sVersionForCELValidation = semver.Version{Major: 1, Minor: 25, Patch: 0}
 )
 
 func getServerVersion(kubeClient kubernetes.Interface) (semver.Version, error) {
@@ -78,4 +84,10 @@ func IsDualStackEnabled(kubeClient kubernetes.Interface) bool {
 // IsSupportedK8sVersionForGatewayAPI returns true if the Kubernetes cluster version is supported by the operator.
 func IsSupportedK8sVersionForGatewayAPI(kubeClient kubernetes.Interface) bool {
 	return IsSupportedK8sVersion(kubeClient)
+}
+
+// IsCELValidationEnabled returns true if CustomResourceValidationExpressions are enabled in the Kubernetes cluster.
+func IsCELValidationEnabled(kubeClient kubernetes.Interface) bool {
+	detectServerVersion(kubeClient)
+	return ServerVersion.GTE(MinK8sVersionForCELValidation)
 }

--- a/pkg/webhook/gateway/gateway_webhook.go
+++ b/pkg/webhook/gateway/gateway_webhook.go
@@ -27,6 +27,8 @@ package gateway
 import (
 	"context"
 	"fmt"
+	gwv1validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1/validation"
+	"github.com/flomesh-io/fsm/pkg/version"
 	"net/http"
 
 	gwutils "github.com/flomesh-io/fsm/pkg/gateway/utils"
@@ -202,8 +204,10 @@ func (w *validator) doValidation(obj interface{}) error {
 		return nil
 	}
 
-	//errorList := gwv1validation.ValidateGateway(gateway)
 	var errorList field.ErrorList
+	if !version.IsCELValidationEnabled(w.kubeClient) {
+		errorList = append(errorList, gwv1validation.ValidateGateway(gateway)...)
+	}
 	errorList = append(errorList, w.validateListenerPort(gateway)...)
 	errorList = append(errorList, w.validateCertificateSecret(gateway)...)
 	if w.cfg.GetFeatureFlags().EnableValidateGatewayListenerHostname {

--- a/pkg/webhook/gateway/gateway_webhook.go
+++ b/pkg/webhook/gateway/gateway_webhook.go
@@ -27,9 +27,10 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	gwv1validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1/validation"
 	"github.com/flomesh-io/fsm/pkg/version"
-	"net/http"
 
 	gwutils "github.com/flomesh-io/fsm/pkg/gateway/utils"
 

--- a/pkg/webhook/grpcroute/grpcroute_webhook.go
+++ b/pkg/webhook/grpcroute/grpcroute_webhook.go
@@ -25,6 +25,8 @@
 package grpcroute
 
 import (
+	gwv1validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1/validation"
+	"github.com/flomesh-io/fsm/pkg/version"
 	"net/http"
 
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -167,8 +169,10 @@ func (w *validator) doValidation(obj interface{}) error {
 		return nil
 	}
 
-	//errorList := gwv1alpha2validation.ValidateGRPCRoute(route)
 	var errorList field.ErrorList
+	if !version.IsCELValidationEnabled(w.kubeClient) {
+		errorList = append(errorList, gwv1validation.ValidateGRPCRoute(route)...)
+	}
 	errorList = append(errorList, webhook.ValidateParentRefs(route.Spec.ParentRefs)...)
 	if w.cfg.GetFeatureFlags().EnableValidateGRPCRouteHostnames {
 		errorList = append(errorList, webhook.ValidateRouteHostnames(route.Spec.Hostnames)...)

--- a/pkg/webhook/grpcroute/grpcroute_webhook.go
+++ b/pkg/webhook/grpcroute/grpcroute_webhook.go
@@ -25,9 +25,10 @@
 package grpcroute
 
 import (
+	"net/http"
+
 	gwv1validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1/validation"
 	"github.com/flomesh-io/fsm/pkg/version"
-	"net/http"
 
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 

--- a/pkg/webhook/httproute/httproute_webhook.go
+++ b/pkg/webhook/httproute/httproute_webhook.go
@@ -25,9 +25,10 @@
 package httproute
 
 import (
+	"net/http"
+
 	gwv1validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1/validation"
 	"github.com/flomesh-io/fsm/pkg/version"
-	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 

--- a/pkg/webhook/httproute/httproute_webhook.go
+++ b/pkg/webhook/httproute/httproute_webhook.go
@@ -25,6 +25,8 @@
 package httproute
 
 import (
+	gwv1validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1/validation"
+	"github.com/flomesh-io/fsm/pkg/version"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -168,6 +170,9 @@ func (w *validator) doValidation(obj interface{}) error {
 
 	//errorList := gwv1validation.ValidateHTTPRoute(route)
 	var errorList field.ErrorList
+	if !version.IsCELValidationEnabled(w.kubeClient) {
+		errorList = append(errorList, gwv1validation.ValidateHTTPRoute(route)...)
+	}
 	errorList = append(errorList, webhook.ValidateParentRefs(route.Spec.ParentRefs)...)
 	if w.cfg.GetFeatureFlags().EnableValidateHTTPRouteHostnames {
 		errorList = append(errorList, webhook.ValidateRouteHostnames(route.Spec.Hostnames)...)

--- a/pkg/webhook/tcproute/tcproute_webhook.go
+++ b/pkg/webhook/tcproute/tcproute_webhook.go
@@ -25,9 +25,10 @@
 package tcproute
 
 import (
+	"net/http"
+
 	gwv1alpha2validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1alpha2/validation"
 	"github.com/flomesh-io/fsm/pkg/version"
-	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 

--- a/pkg/webhook/tlsroute/tlsproute_webhook.go
+++ b/pkg/webhook/tlsroute/tlsproute_webhook.go
@@ -25,8 +25,9 @@
 package tlsroute
 
 import (
-	"github.com/flomesh-io/fsm/pkg/version"
 	"net/http"
+
+	"github.com/flomesh-io/fsm/pkg/version"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 

--- a/pkg/webhook/tlsroute/tlsproute_webhook.go
+++ b/pkg/webhook/tlsroute/tlsproute_webhook.go
@@ -25,6 +25,7 @@
 package tlsroute
 
 import (
+	"github.com/flomesh-io/fsm/pkg/version"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -35,6 +36,7 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	flomeshadmission "github.com/flomesh-io/fsm/pkg/admission"
+	gwv1alpha2validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1alpha2/validation"
 	"github.com/flomesh-io/fsm/pkg/configurator"
 	"github.com/flomesh-io/fsm/pkg/constants"
 	"github.com/flomesh-io/fsm/pkg/utils"
@@ -166,8 +168,10 @@ func (w *validator) doValidation(obj interface{}) error {
 		return nil
 	}
 
-	//errorList := gwv1alpha2validation.ValidateTLSRoute(route)
 	var errorList field.ErrorList
+	if !version.IsCELValidationEnabled(w.kubeClient) {
+		errorList = append(errorList, gwv1alpha2validation.ValidateTLSRoute(route)...)
+	}
 	errorList = append(errorList, webhook.ValidateParentRefs(route.Spec.ParentRefs)...)
 	if w.cfg.GetFeatureFlags().EnableValidateTLSRouteHostnames {
 		errorList = append(errorList, webhook.ValidateRouteHostnames(route.Spec.Hostnames)...)

--- a/pkg/webhook/udproute/udproute_webhook.go
+++ b/pkg/webhook/udproute/udproute_webhook.go
@@ -25,9 +25,10 @@
 package udproute
 
 import (
+	"net/http"
+
 	gwv1alpha2validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1alpha2/validation"
 	"github.com/flomesh-io/fsm/pkg/version"
-	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 

--- a/pkg/webhook/udproute/udproute_webhook.go
+++ b/pkg/webhook/udproute/udproute_webhook.go
@@ -25,6 +25,8 @@
 package udproute
 
 import (
+	gwv1alpha2validation "github.com/flomesh-io/fsm/pkg/apis/gateway/v1alpha2/validation"
+	"github.com/flomesh-io/fsm/pkg/version"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -139,12 +141,12 @@ func (w *validator) RuntimeObject() runtime.Object {
 
 // ValidateCreate validates the creation of the UDPRoute
 func (w *validator) ValidateCreate(obj interface{}) error {
-	return doValidation(obj)
+	return w.doValidation(obj)
 }
 
 // ValidateUpdate validates the update of the UDPRoute
 func (w *validator) ValidateUpdate(_, obj interface{}) error {
-	return doValidation(obj)
+	return w.doValidation(obj)
 }
 
 // ValidateDelete validates the deletion of the UDPRoute
@@ -158,14 +160,16 @@ func newValidator(kubeClient kubernetes.Interface) *validator {
 	}
 }
 
-func doValidation(obj interface{}) error {
+func (w *validator) doValidation(obj interface{}) error {
 	route, ok := obj.(*gwv1alpha2.UDPRoute)
 	if !ok {
 		return nil
 	}
 
-	//errorList := gwv1alpha2validation.ValidateUDPRoute(route)
 	var errorList field.ErrorList
+	if !version.IsCELValidationEnabled(w.kubeClient) {
+		errorList = append(errorList, gwv1alpha2validation.ValidateUDPRoute(route)...)
+	}
 	errorList = append(errorList, webhook.ValidateParentRefs(route.Spec.ParentRefs)...)
 	if len(errorList) > 0 {
 		return utils.ErrorListToError(errorList)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?