### PR TITLE
Support specifying sidecar's image for pod and namespace.

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -207,6 +207,9 @@ const (
 	// SidecarInjectionAnnotation is the annotation used for sidecar injection
 	SidecarInjectionAnnotation = "flomesh.io/sidecar-injection"
 
+	// SidecarImageAnnotation is the annotation used for sidecar injection
+	SidecarImageAnnotation = "flomesh.io/sidecar-image"
+
 	// MetricsAnnotation is the annotation used for enabling/disabling metrics
 	MetricsAnnotation = "flomesh.io/metrics"
 

--- a/pkg/sidecar/providers/pipy/driver/pipy_container.go
+++ b/pkg/sidecar/providers/pipy/driver/pipy_container.go
@@ -21,7 +21,7 @@ import (
 	"github.com/flomesh-io/fsm/pkg/sidecar/providers/pipy/bootstrap"
 )
 
-func getPlatformSpecificSpecComponents(cfg configurator.Configurator, _ string) (podSecurityContext *corev1.SecurityContext, pipyContainer string) {
+func getPlatformSpecificSpecComponents(injCtx *driver.InjectorContext, cfg configurator.Configurator, pod *corev1.Pod) (podSecurityContext *corev1.SecurityContext, pipyContainer string) {
 	podSecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: pointer.BoolPtr(false),
 		RunAsUser: func() *int64 {
@@ -29,12 +29,33 @@ func getPlatformSpecificSpecComponents(cfg configurator.Configurator, _ string) 
 			return &uid
 		}(),
 	}
+
+	if podAnnotations := pod.GetAnnotations(); len(podAnnotations) > 0 {
+		if podSidecarImage, exists := podAnnotations[constants.SidecarImageAnnotation]; exists {
+			if len(podSidecarImage) > 0 {
+				pipyContainer = podSidecarImage
+				return
+			}
+		}
+	}
+
+	if ns, err := injCtx.KubeClient.CoreV1().Namespaces().Get(context.Background(), injCtx.PodNamespace, metav1.GetOptions{}); err == nil {
+		if nsAnnotations := ns.GetAnnotations(); len(nsAnnotations) > 0 {
+			if nsSidecarImage, exists := nsAnnotations[constants.SidecarImageAnnotation]; exists {
+				if len(nsSidecarImage) > 0 {
+					pipyContainer = nsSidecarImage
+					return
+				}
+			}
+		}
+	}
+
 	pipyContainer = cfg.GetSidecarImage()
 	return
 }
 
 func getPipySidecarContainerSpec(injCtx *driver.InjectorContext, pod *corev1.Pod, cfg configurator.Configurator, cnPrefix string, originalHealthProbes models.HealthProbes, podOS string) corev1.Container {
-	securityContext, containerImage := getPlatformSpecificSpecComponents(cfg, podOS)
+	securityContext, containerImage := getPlatformSpecificSpecComponents(injCtx, cfg, pod)
 
 	podControllerKind := ""
 	podControllerName := ""


### PR DESCRIPTION
…tation for pod and namespace.

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Support specifying sidecar's image by "flomesh.io/sidecar-image" annotation for pod and namespace.
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)? no