### PR TITLE
fix(deps): bump pipy of all images to 1.5.0

### DIFF
--- a/cmd/fsm-bootstrap/crds/config.flomesh.io_meshconfigs.yaml
+++ b/cmd/fsm-bootstrap/crds/config.flomesh.io_meshconfigs.yaml
@@ -1796,7 +1796,7 @@ spec:
                 description: Misc defines the configurations of misc info
                 properties:
                   repoServerImage:
-                    default: flomesh/pipy-repo:1.4.3
+                    default: flomesh/pipy-repo:1.5.0
                     description: RepoServerImage defines the image of repo server.
                     type: string
                 required:

--- a/dockerfiles/Dockerfile.fsm-gateway
+++ b/dockerfiles/Dockerfile.fsm-gateway
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v -o bin/fsm-gateway -ldflags "$LDFLAGS" ./cmd/fsm-gateway
 
 # Build the final image
-FROM flomesh/pipy:1.4.3-$DISTROLESS_TAG
+FROM flomesh/pipy:1.5.0-$DISTROLESS_TAG
 WORKDIR /
 COPY --from=builder /fsm/bin/fsm-gateway .
 

--- a/dockerfiles/Dockerfile.fsm-ingress
+++ b/dockerfiles/Dockerfile.fsm-ingress
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v -o bin/fsm-ingress -ldflags "$LDFLAGS" ./cmd/fsm-ingress
 
 # Build the final image
-FROM flomesh/pipy:1.4.3-$DISTROLESS_TAG
+FROM flomesh/pipy:1.5.0-$DISTROLESS_TAG
 WORKDIR /
 COPY --from=builder /fsm/bin/fsm-ingress .
 

--- a/docs/tests/gateway-api/README.md
+++ b/docs/tests/gateway-api/README.md
@@ -298,7 +298,7 @@ spec:
     spec:
       containers:
         - name: pipy
-          image: flomesh/pipy:1.4.3
+          image: flomesh/pipy:1.5.0
           ports:
             - name: pipy
               containerPort: 8080
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: pipy
-          image: flomesh/pipy:1.4.3
+          image: flomesh/pipy:1.5.0
           ports:
             - name: pipy
               containerPort: 8080

--- a/pkg/apis/config/v1alpha3/mesh_config.go
+++ b/pkg/apis/config/v1alpha3/mesh_config.go
@@ -782,7 +782,7 @@ type ImageSpec struct {
 
 // MiscSpec is the type to represent misc configs.
 type MiscSpec struct {
-	// +kubebuilder:default="flomesh/pipy-repo:1.4.3"
+	// +kubebuilder:default="flomesh/pipy-repo:1.5.0"
 	// RepoServerImage defines the image of repo server.
 	RepoServerImage string `json:"repoServerImage"`
 }

--- a/tests/e2e/e2e_fsm_ingress_test.go
+++ b/tests/e2e/e2e_fsm_ingress_test.go
@@ -243,7 +243,7 @@ func deployAppForTestingIngress() {
 					Containers: []corev1.Container{
 						{
 							Name:  "pipy",
-							Image: "flomesh/pipy:1.4.3",
+							Image: "flomesh/pipy:1.5.0",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "pipy",

--- a/tests/e2e/e2e_gatewayapi_test.go
+++ b/tests/e2e/e2e_gatewayapi_test.go
@@ -351,7 +351,7 @@ func testFSMGatewayHTTPTrafficSameNamespace() {
 					Containers: []corev1.Container{
 						{
 							Name:  "pipy",
-							Image: "flomesh/pipy:1.4.3",
+							Image: "flomesh/pipy:1.5.0",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "pipy",
@@ -478,7 +478,7 @@ func testFSMGatewayHTTPTrafficCrossNamespace() {
 					Containers: []corev1.Container{
 						{
 							Name:  "pipy",
-							Image: "flomesh/pipy:1.4.3",
+							Image: "flomesh/pipy:1.5.0",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "pipy",


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?