### PR TITLE
[backport] build(deps): bump pipy from 1.5.5 to 1.5.7

### DIFF
--- a/charts/fsm/README.md
+++ b/charts/fsm/README.md
@@ -436,11 +436,11 @@ The following table lists the configurable parameters of the fsm chart and their
 | fsm.remoteLogging.port | int | `30514` | Port of the remote logging service |
 | fsm.remoteLogging.sampledFraction | string | `"1.0"` | Sampled Fraction |
 | fsm.remoteLogging.secretName | string | `"fsm-remote-logging-secret"` | Secret Name |
-| fsm.repoServer | object | `{"codebase":"","image":{"name":"pipy-repo","registry":"flomesh","tag":"1.5.5"},"ipaddr":"127.0.0.1","port":6060,"standalone":false}` | Pipy RepoServer |
+| fsm.repoServer | object | `{"codebase":"","image":{"name":"pipy-repo","registry":"flomesh","tag":"1.5.7"},"ipaddr":"127.0.0.1","port":6060,"standalone":false}` | Pipy RepoServer |
 | fsm.repoServer.codebase | string | `""` | codebase is the folder used by fsmController. |
 | fsm.repoServer.image.name | string | `"pipy-repo"` | Repo server image name |
 | fsm.repoServer.image.registry | string | `"flomesh"` | Registry for repo server image |
-| fsm.repoServer.image.tag | string | `"1.5.5"` | Repo server image tag |
+| fsm.repoServer.image.tag | string | `"1.5.7"` | Repo server image tag |
 | fsm.repoServer.ipaddr | string | `"127.0.0.1"` | ipaddr of host/service where Pipy RepoServer is installed |
 | fsm.repoServer.port | int | `6060` | port of pipy RepoServer |
 | fsm.repoServer.standalone | bool | `false` | if false , Pipy RepoServer is installed within fsmController pod. |
@@ -449,11 +449,11 @@ The following table lists the configurable parameters of the fsm chart and their
 | fsm.serviceLB.image.name | string | `"mirrored-klipper-lb"` | service-lb image name |
 | fsm.serviceLB.image.registry | string | `"flomesh"` | Registry for service-lb image |
 | fsm.serviceLB.image.tag | string | `"v0.4.7"` | service-lb image tag |
-| fsm.sidecar | object | `{"compressConfig":true,"image":{"name":"pipy","registry":"flomesh","tag":"1.5.5"},"sidecarDisabledMTLS":false,"sidecarLogLevel":"error","sidecarTimeout":60}` | Sidecar supported by fsm |
+| fsm.sidecar | object | `{"compressConfig":true,"image":{"name":"pipy","registry":"flomesh","tag":"1.5.7"},"sidecarDisabledMTLS":false,"sidecarLogLevel":"error","sidecarTimeout":60}` | Sidecar supported by fsm |
 | fsm.sidecar.compressConfig | bool | `true` | Sidecar compresses config.json |
 | fsm.sidecar.image.name | string | `"pipy"` | Sidecar image name |
 | fsm.sidecar.image.registry | string | `"flomesh"` | Registry for sidecar image |
-| fsm.sidecar.image.tag | string | `"1.5.5"` | Sidecar image tag |
+| fsm.sidecar.image.tag | string | `"1.5.7"` | Sidecar image tag |
 | fsm.sidecar.sidecarDisabledMTLS | bool | `false` | Sidecar runs without mTLS |
 | fsm.sidecar.sidecarLogLevel | string | `"error"` | Log level for the proxy sidecar. Non developers should generally never set this value. In production environments the LogLevel should be set to `error` |
 | fsm.sidecar.sidecarTimeout | int | `60` | Sets connect/idle/read/write timeout |

--- a/charts/fsm/values.yaml
+++ b/charts/fsm/values.yaml
@@ -76,7 +76,7 @@ fsm:
       # -- Sidecar image name
       name: pipy
       # -- Sidecar image tag
-      tag: 1.5.5
+      tag: 1.5.7
     # -- Sidecar runs without mTLS
     sidecarDisabledMTLS: false
     # -- Sidecar compresses config.json
@@ -94,7 +94,7 @@ fsm:
       # -- Repo server image name
       name: pipy-repo
       # -- Repo server image tag
-      tag: 1.5.5
+      tag: 1.5.7
     # -- if false , Pipy RepoServer is installed within fsmController pod.
     standalone: false
     # -- ipaddr of host/service where Pipy RepoServer is installed

--- a/cmd/fsm-bootstrap/crds/config.flomesh.io_meshconfigs.yaml
+++ b/cmd/fsm-bootstrap/crds/config.flomesh.io_meshconfigs.yaml
@@ -1736,7 +1736,7 @@ spec:
                 description: Misc defines the configurations of misc info
                 properties:
                   repoServerImage:
-                    default: flomesh/pipy-repo:1.5.5
+                    default: flomesh/pipy-repo:1.5.7
                     description: RepoServerImage defines the image of repo server.
                     type: string
                 required:

--- a/dockerfiles/Dockerfile.fsm-gateway
+++ b/dockerfiles/Dockerfile.fsm-gateway
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v -o bin/fsm-gateway -ldflags "$LDFLAGS" ./cmd/fsm-gateway
 
 # Build the final image
-FROM flomesh/pipy:1.5.5-$DISTROLESS_TAG
+FROM flomesh/pipy:1.5.7-$DISTROLESS_TAG
 WORKDIR /
 COPY --from=builder /fsm/bin/fsm-gateway .
 

--- a/dockerfiles/Dockerfile.fsm-ingress
+++ b/dockerfiles/Dockerfile.fsm-ingress
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v -o bin/fsm-ingress -ldflags "$LDFLAGS" ./cmd/fsm-ingress
 
 # Build the final image
-FROM flomesh/pipy:1.5.5-$DISTROLESS_TAG
+FROM flomesh/pipy:1.5.7-$DISTROLESS_TAG
 WORKDIR /
 COPY --from=builder /fsm/bin/fsm-ingress .
 

--- a/docs/tests/gateway-api/README.md
+++ b/docs/tests/gateway-api/README.md
@@ -298,7 +298,7 @@ spec:
     spec:
       containers:
         - name: pipy
-          image: flomesh/pipy:1.5.5
+          image: flomesh/pipy:1.5.7
           ports:
             - name: pipy
               containerPort: 8080
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: pipy
-          image: flomesh/pipy:1.5.5
+          image: flomesh/pipy:1.5.7
           ports:
             - name: pipy
               containerPort: 8080

--- a/pkg/apis/config/v1alpha3/mesh_config.go
+++ b/pkg/apis/config/v1alpha3/mesh_config.go
@@ -746,7 +746,7 @@ type ImageSpec struct {
 
 // MiscSpec is the type to represent misc configs.
 type MiscSpec struct {
-	// +kubebuilder:default="flomesh/pipy-repo:1.5.5"
+	// +kubebuilder:default="flomesh/pipy-repo:1.5.7"
 	// RepoServerImage defines the image of repo server.
 	RepoServerImage string `json:"repoServerImage"`
 }

--- a/tests/e2e/e2e_fsm_ingress_test.go
+++ b/tests/e2e/e2e_fsm_ingress_test.go
@@ -243,7 +243,7 @@ func deployAppForTestingIngress() {
 					Containers: []corev1.Container{
 						{
 							Name:  "pipy",
-							Image: "flomesh/pipy:1.5.5",
+							Image: "flomesh/pipy:1.5.7",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "pipy",

--- a/tests/e2e/e2e_gatewayapi_test.go
+++ b/tests/e2e/e2e_gatewayapi_test.go
@@ -351,7 +351,7 @@ func testFSMGatewayHTTPTrafficSameNamespace() {
 					Containers: []corev1.Container{
 						{
 							Name:  "pipy",
-							Image: "flomesh/pipy:1.5.5",
+							Image: "flomesh/pipy:1.5.7",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "pipy",
@@ -478,7 +478,7 @@ func testFSMGatewayHTTPTrafficCrossNamespace() {
 					Containers: []corev1.Container{
 						{
 							Name:  "pipy",
-							Image: "flomesh/pipy:1.5.5",
+							Image: "flomesh/pipy:1.5.7",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "pipy",


### PR DESCRIPTION
Backport #503 to `release/v1.4`.