### PR TITLE
fix: increase k3d cluster CIDR range from /24 to /16

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: boolean
         default: ${{ vars.FREE_DISK_SPACE == 'true' }}
+      increase_k3d_cidr_range:
+        required: false
+        type: boolean
+        default: false
 
 env:
   FSM_HUMAN_DEBUG_LOG: ${{ vars.FSM_HUMAN_DEBUG_LOG || 'false' }}
@@ -95,6 +99,7 @@ jobs:
         env:
           K8S_NAMESPACE: "fsm-system"
           LOAD_IMAGES_INTO_CLUSTER: "true"
+          INCREASE_K3D_CIDR_RANGE: ${{ inputs.increase_k3d_cidr_range }}
         run: |
           export PATH=$PWD/bin:$PATH
           echo "PATH=$PATH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -297,7 +297,7 @@ jobs:
       focus: ${{ matrix.focus }}
       install_grpcurl: true
       add_hosts: true
-      increase_k3d_cidr_range: ${{ matrix.bucket == '7' }}
+      increase_k3d_cidr_range: false
     secrets: inherit
 
   ingress-e2e-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,7 +268,8 @@ jobs:
     strategy:
       matrix:
         focus: [""]
-        bucket: [6, 7]
+#        bucket: [6, 7]
+        bucket: [6]
         k8s:
           - version: "latest"
             os: ubuntu-24.04
@@ -278,17 +279,17 @@ jobs:
             os: ubuntu-24.04
           - version: v1.23.17-k3s1
             os: ubuntu-24.04
-        exclude:
-          - focus: ""
-            bucket: "7"
-            k8s:
-              version: v1.21.14-k3s1
-              os: ubuntu-24.04
-          - focus: ""
-            bucket: "7"
-            k8s:
-              version: v1.23.17-k3s1
-              os: ubuntu-24.04
+#        exclude:
+#          - focus: ""
+#            bucket: "7"
+#            k8s:
+#              version: v1.21.14-k3s1
+#              os: ubuntu-24.04
+#          - focus: ""
+#            bucket: "7"
+#            k8s:
+#              version: v1.23.17-k3s1
+#              os: ubuntu-24.04
     uses: ./.github/workflows/e2e.yml
     with:
       os: ${{ matrix.k8s.os }}
@@ -297,7 +298,6 @@ jobs:
       focus: ${{ matrix.focus }}
       install_grpcurl: true
       add_hosts: true
-      increase_k3d_cidr_range: false
     secrets: inherit
 
   ingress-e2e-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -297,6 +297,7 @@ jobs:
       focus: ${{ matrix.focus }}
       install_grpcurl: true
       add_hosts: true
+      increase_k3d_cidr_range: ${{ matrix.bucket == '7' }}
     secrets: inherit
 
   ingress-e2e-test:

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cskr/pubsub v1.0.2
 	github.com/deckarep/golang-set v1.8.0
 	github.com/deckarep/golang-set/v2 v2.8.0
-	github.com/docker/distribution v2.8.3+incompatible
+	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v27.5.0+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/dubbogo/go-zookeeper v1.0.3
@@ -242,8 +242,8 @@ require (
 	github.com/digitalocean/godo v1.125.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/disintegration/imaging v1.6.2 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v27.2.1+incompatible // indirect
+	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.1 // indirect
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/pkg/utils/image.go
+++ b/pkg/utils/image.go
@@ -11,7 +11,7 @@ import (
 	//  Import the crypto/sha512 algorithm for the docker image parser to work with 384 and 512 sha hashes
 	_ "crypto/sha512"
 
-	dockerref "github.com/docker/distribution/reference"
+	dockerref "github.com/distribution/reference"
 )
 
 // ParseImageName parses a docker image string into three parts: repo, tag and digest.

--- a/scripts/k3d-with-registry.sh
+++ b/scripts/k3d-with-registry.sh
@@ -143,11 +143,9 @@ options:
       - arg: --cluster-cidr=10.42.0.0/16
         nodeFilters:
           - server:*
-          - agent:*
       - arg: --service-cidr=10.43.0.0/16
         nodeFilters:
           - server:*
-          - agent:*
     nodeLabels:
       - label: ingress-ready=true
         nodeFilters:

--- a/scripts/k3d-with-registry.sh
+++ b/scripts/k3d-with-registry.sh
@@ -146,7 +146,7 @@ options:
       - arg: --service-cidr=10.43.0.0/16
         nodeFilters:
           - server:*
-      - arg: --node-cidr-mask-size-ipv4=22
+      - arg: --kube-controller-manager-arg=node-cidr-mask-size-ipv4=22
         nodeFilters:
           - server:*
     nodeLabels:

--- a/scripts/k3d-with-registry.sh
+++ b/scripts/k3d-with-registry.sh
@@ -146,6 +146,9 @@ options:
       - arg: --service-cidr=10.43.0.0/16
         nodeFilters:
           - server:*
+      - arg: --node-cidr-mask-size-ipv4=22
+        nodeFilters:
+          - server:*
     nodeLabels:
       - label: ingress-ready=true
         nodeFilters:

--- a/scripts/k3d-with-registry.sh
+++ b/scripts/k3d-with-registry.sh
@@ -140,15 +140,6 @@ options:
         nodeFilters:
           - server:*
           - agent:*
-      - arg: --cluster-cidr=10.42.0.0/16
-        nodeFilters:
-          - server:*
-      - arg: --service-cidr=10.43.0.0/16
-        nodeFilters:
-          - server:*
-      - arg: --kube-controller-manager-arg=node-cidr-mask-size-ipv4=22
-        nodeFilters:
-          - server:*
     nodeLabels:
       - label: ingress-ready=true
         nodeFilters:

--- a/scripts/k3d-with-registry.sh
+++ b/scripts/k3d-with-registry.sh
@@ -140,6 +140,14 @@ options:
         nodeFilters:
           - server:*
           - agent:*
+      - arg: --cluster-cidr=10.42.0.0/16
+        nodeFilters:
+          - server:*
+          - agent:*
+      - arg: --service-cidr=10.43.0.0/16
+        nodeFilters:
+          - server:*
+          - agent:*
     nodeLabels:
       - label: ingress-ready=true
         nodeFilters:

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -607,11 +607,24 @@ func (td *FsmTestData) k3dClusterConfig() *k3dCfg.ClusterConfig {
 				Arg:         "--service-cidr=10.43.0.0/16",
 				NodeFilters: []string{"server:*"},
 			},
-			{
-				Arg:         "--kube-controller-manager-arg=node-cidr-mask-size-ipv4=22",
-				NodeFilters: []string{"server:*"},
-			},
 		}...)
+
+		_, tag, _, _ := utils.ParseImageName(simpleCfg.Image)
+		if strings.HasPrefix(tag, "v1.19.") || strings.HasPrefix(tag, "v1.20.") {
+			simpleCfg.Options.K3sOptions.ExtraArgs = append(simpleCfg.Options.K3sOptions.ExtraArgs, []k3dCfg.K3sArgWithNodeFilters{
+				{
+					Arg:         "--kube-controller-manager-arg=node-cidr-mask-size=22",
+					NodeFilters: []string{"server:*"},
+				},
+			}...)
+		} else {
+			simpleCfg.Options.K3sOptions.ExtraArgs = append(simpleCfg.Options.K3sOptions.ExtraArgs, []k3dCfg.K3sArgWithNodeFilters{
+				{
+					Arg:         "--kube-controller-manager-arg=node-cidr-mask-size-ipv4=22",
+					NodeFilters: []string{"server:*"},
+				},
+			}...)
+		}
 	}
 
 	if err := config.ProcessSimpleConfig(&simpleCfg); err != nil {

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -326,7 +326,7 @@ func (td *FsmTestData) InitTestData(t GinkgoTInterface) error {
 
 					name := c.Names[0]
 					td.T.Logf("Conainer name: %s", name)
-					if !strings.HasPrefix(name, fmt.Sprintf("/k3d-%s-", Td.ClusterName)) {
+					if !strings.HasPrefix(name, fmt.Sprintf("/k3d-%s-server-", Td.ClusterName)) && !strings.HasPrefix(name, fmt.Sprintf("/k3d-%s-agent-", Td.ClusterName)) {
 						continue
 					}
 

--- a/tests/framework/k3d-cluster.yaml
+++ b/tests/framework/k3d-cluster.yaml
@@ -61,15 +61,15 @@ options:
         nodeFilters:
           - server:*
           - agent:*
-      - arg: --cluster-cidr=10.42.0.0/16
-        nodeFilters:
-          - server:*
-      - arg: --service-cidr=10.43.0.0/16
-        nodeFilters:
-          - server:*
-      - arg: --kube-controller-manager-arg=node-cidr-mask-size-ipv4=22
-        nodeFilters:
-          - server:*
+#      - arg: --cluster-cidr=10.42.0.0/16
+#        nodeFilters:
+#          - server:*
+#      - arg: --service-cidr=10.43.0.0/16
+#        nodeFilters:
+#          - server:*
+#      - arg: --kube-controller-manager-arg=node-cidr-mask-size-ipv4=22
+#        nodeFilters:
+#          - server:*
     nodeLabels:
       - label: ingress-ready=true
         nodeFilters:

--- a/tests/framework/k3d-cluster.yaml
+++ b/tests/framework/k3d-cluster.yaml
@@ -70,7 +70,7 @@ options:
       - arg: --service-cidr=10.43.0.0/16
         nodeFilters:
           - server:*
-      - arg: --node-cidr-mask-size-ipv4=22
+      - arg: --kube-controller-manager-arg=node-cidr-mask-size-ipv4=22
         nodeFilters:
           - server:*
     nodeLabels:

--- a/tests/framework/k3d-cluster.yaml
+++ b/tests/framework/k3d-cluster.yaml
@@ -4,9 +4,6 @@ metadata:
   name: fsm-e2e
 servers: 1
 agents: 1
-kubeAPI:
-  hostIP: "0.0.0.0"
-  hostPort: "6443"
 ports:
   - port: 80:80
     nodeFilters:

--- a/tests/framework/k3d-cluster.yaml
+++ b/tests/framework/k3d-cluster.yaml
@@ -70,6 +70,9 @@ options:
       - arg: --service-cidr=10.43.0.0/16
         nodeFilters:
           - server:*
+      - arg: --node-cidr-mask-size-ipv4=22
+        nodeFilters:
+          - server:*
     nodeLabels:
       - label: ingress-ready=true
         nodeFilters:

--- a/tests/framework/k3d-cluster.yaml
+++ b/tests/framework/k3d-cluster.yaml
@@ -64,6 +64,14 @@ options:
         nodeFilters:
           - server:*
           - agent:*
+      - arg: --cluster-cidr=10.42.0.0/16
+        nodeFilters:
+          - server:*
+          - agent:*
+      - arg: --service-cidr=10.43.0.0/16
+        nodeFilters:
+          - server:*
+          - agent:*
     nodeLabels:
       - label: ingress-ready=true
         nodeFilters:

--- a/tests/framework/k3d-cluster.yaml
+++ b/tests/framework/k3d-cluster.yaml
@@ -61,15 +61,6 @@ options:
         nodeFilters:
           - server:*
           - agent:*
-#      - arg: --cluster-cidr=10.42.0.0/16
-#        nodeFilters:
-#          - server:*
-#      - arg: --service-cidr=10.43.0.0/16
-#        nodeFilters:
-#          - server:*
-#      - arg: --kube-controller-manager-arg=node-cidr-mask-size-ipv4=22
-#        nodeFilters:
-#          - server:*
     nodeLabels:
       - label: ingress-ready=true
         nodeFilters:

--- a/tests/framework/k3d-cluster.yaml
+++ b/tests/framework/k3d-cluster.yaml
@@ -67,11 +67,9 @@ options:
       - arg: --cluster-cidr=10.42.0.0/16
         nodeFilters:
           - server:*
-          - agent:*
       - arg: --service-cidr=10.43.0.0/16
         nodeFilters:
           - server:*
-          - agent:*
     nodeLabels:
       - label: ingress-ready=true
         nodeFilters:

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -110,6 +110,7 @@ type FsmTestData struct {
 
 	K3dNodeLogs           bool // Whether to collect logs from k3d nodes
 	LoadImagesIntoCluster bool // Whether to load images into the cluster
+	IncreaseK3dCIDRRange  bool // Whether to increase the CIDR range of the k3d cluster
 }
 
 // InstallFSMOpts describes install options for FSM


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?