### PR TITLE
[backport] fix: default time unit in config should be seconds(release/v1.4)

### DIFF
--- a/pkg/gateway/fgw/config.go
+++ b/pkg/gateway/fgw/config.go
@@ -631,30 +631,30 @@ func (c *HealthCheckConfig) FailTimeout(failTimeout *metav1.Duration) {
 // ---
 
 type CircuitBreakerSpec struct {
-	LatencyThresholdInMilliseconds *int64                              `json:"latencyThreshold,omitempty"`
-	ErrorCountThreshold            *int32                              `json:"errorCountThreshold,omitempty"`
-	ErrorRatioThreshold            *float32                            `json:"errorRatioThreshold,omitempty"`
-	ConcurrencyThreshold           *int32                              `json:"concurrencyThreshold,omitempty"`
-	CheckIntervalInMilliseconds    *int64                              `json:"checkInterval,omitempty"`
-	BreakIntervalInMilliseconds    *int64                              `json:"breakInterval,omitempty"`
-	CircuitBreakerResponse         *extv1alpha1.CircuitBreakerResponse `json:"response,omitempty"`
+	LatencyThresholdInSeconds *float64                            `json:"latencyThreshold,omitempty"`
+	ErrorCountThreshold       *int32                              `json:"errorCountThreshold,omitempty"`
+	ErrorRatioThreshold       *float32                            `json:"errorRatioThreshold,omitempty"`
+	ConcurrencyThreshold      *int32                              `json:"concurrencyThreshold,omitempty"`
+	CheckIntervalInSeconds    *float64                            `json:"checkInterval,omitempty"`
+	BreakIntervalInSeconds    *float64                            `json:"breakInterval,omitempty"`
+	CircuitBreakerResponse    *extv1alpha1.CircuitBreakerResponse `json:"response,omitempty"`
 }
 
 func (c *CircuitBreakerSpec) LatencyThreshold(latencyThreshold *metav1.Duration) {
 	if latencyThreshold != nil {
-		c.LatencyThresholdInMilliseconds = ptr.To(latencyThreshold.Milliseconds())
+		c.LatencyThresholdInSeconds = ptr.To(math.Ceil(latencyThreshold.Seconds()*1000) / 1000)
 	}
 }
 
 func (c *CircuitBreakerSpec) CheckInterval(checkInterval *metav1.Duration) {
 	if checkInterval != nil {
-		c.CheckIntervalInMilliseconds = ptr.To(checkInterval.Milliseconds())
+		c.CheckIntervalInSeconds = ptr.To(math.Ceil(checkInterval.Seconds()*1000) / 1000)
 	}
 }
 
 func (c *CircuitBreakerSpec) BreakInterval(breakInterval *metav1.Duration) {
 	if breakInterval != nil {
-		c.BreakIntervalInMilliseconds = ptr.To(breakInterval.Milliseconds())
+		c.BreakIntervalInSeconds = ptr.To(math.Ceil(breakInterval.Seconds()*1000) / 1000)
 	}
 }
 
@@ -666,36 +666,36 @@ type FaultInjectionSpec struct {
 }
 
 type FaultInjectionDelay struct {
-	Percentage        int32  `json:"percentage"`
-	MinInMilliseconds *int64 `json:"min,omitempty"`
-	MaxInMilliseconds *int64 `json:"max,omitempty"`
+	Percentage   int32    `json:"percentage"`
+	MinInSeconds *float64 `json:"min,omitempty"`
+	MaxInSeconds *float64 `json:"max,omitempty"`
 }
 
 func (f *FaultInjectionDelay) Min(min *metav1.Duration) {
 	if min != nil {
-		f.MinInMilliseconds = ptr.To(min.Milliseconds())
+		f.MinInSeconds = ptr.To(math.Ceil(min.Seconds()*1000) / 1000)
 	}
 }
 
 func (f *FaultInjectionDelay) Max(max *metav1.Duration) {
 	if max != nil {
-		f.MaxInMilliseconds = ptr.To(max.Milliseconds())
+		f.MaxInSeconds = ptr.To(math.Ceil(max.Seconds()*1000) / 1000)
 	}
 }
 
 // ---
 
 type RateLimitSpec struct {
-	Burst                  *int32                         `json:"burst,omitempty"`
-	Requests               *int32                         `json:"requests,omitempty"`
-	IntervalInMilliseconds *int64                         `json:"interval,omitempty"`
-	Backlog                *int32                         `json:"backlog,omitempty"`
-	RateLimitResponse      *extv1alpha1.RateLimitResponse `json:"response,omitempty"`
+	Burst             *int32                         `json:"burst,omitempty"`
+	Requests          *int32                         `json:"requests,omitempty"`
+	IntervalInSeconds *float64                       `json:"interval,omitempty"`
+	Backlog           *int32                         `json:"backlog,omitempty"`
+	RateLimitResponse *extv1alpha1.RateLimitResponse `json:"response,omitempty"`
 }
 
 func (r *RateLimitSpec) Interval(interval *metav1.Duration) {
 	if interval != nil {
-		r.IntervalInMilliseconds = ptr.To(interval.Milliseconds())
+		r.IntervalInSeconds = ptr.To(math.Ceil(interval.Seconds()*1000) / 1000)
 	}
 }
 
@@ -710,27 +710,27 @@ type HTTPLogSpec struct {
 }
 
 type HTTPLogBatch struct {
-	Size                   *int32  `json:"size,omitempty"`
-	IntervalInMilliseconds *int64  `json:"interval,omitempty"`
-	Prefix                 *string `json:"prefix,omitempty"`
-	Postfix                *string `json:"postfix,omitempty"`
-	Separator              *string `json:"separator,omitempty"`
+	Size              *int32   `json:"size,omitempty"`
+	IntervalInSeconds *float64 `json:"interval,omitempty"`
+	Prefix            *string  `json:"prefix,omitempty"`
+	Postfix           *string  `json:"postfix,omitempty"`
+	Separator         *string  `json:"separator,omitempty"`
 }
 
 func (b *HTTPLogBatch) Interval(interval *metav1.Duration) {
 	if interval != nil {
-		b.IntervalInMilliseconds = ptr.To(interval.Milliseconds())
+		b.IntervalInSeconds = ptr.To(math.Ceil(interval.Seconds()*1000) / 1000)
 	}
 }
 
 // ---
 
 type MetricsSpec struct {
-	SampleIntervalInMilliseconds *int64 `json:"sampleInterval,omitempty"`
+	SampleIntervalInSeconds *float64 `json:"sampleInterval,omitempty"`
 }
 
 func (m *MetricsSpec) SampleInterval(sampleInterval *metav1.Duration) {
 	if sampleInterval != nil {
-		m.SampleIntervalInMilliseconds = ptr.To(sampleInterval.Milliseconds())
+		m.SampleIntervalInSeconds = ptr.To(math.Ceil(sampleInterval.Seconds()*1000) / 1000)
 	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [fsm-docs](https://github.com/flomesh-io/fsm-docs/) repo (if applicable)?