### PR TITLE
fix: Incorrect conversion between integer types

### DIFF
--- a/pkg/connector/ktoc/source.go
+++ b/pkg/connector/ktoc/source.go
@@ -507,7 +507,7 @@ func (t *KtoCSource) determinePortAnnotations(svc *corev1.Service, baseService c
 		// If a specific port is specified, then use that port value
 		portAnnotation, ok := svc.Annotations[connector.AnnotationServicePort]
 		if ok {
-			if v, err := strconv.ParseInt(portAnnotation, 0, 0); err == nil {
+			if v, err := strconv.ParseInt(portAnnotation, 0, 32); err == nil {
 				port = int32(v)
 				overridePortNumber = port
 			} else {

--- a/pkg/connector/provider/nacos.go
+++ b/pkg/connector/provider/nacos.go
@@ -439,7 +439,11 @@ func (dc *NacosDiscoveryClient) Deregister(dereg *connector.CatalogDeregistratio
 	if ins == nil {
 		return nil
 	}
-	port, _ := strconv.Atoi(fmt.Sprintf("%d", ins.Port))
+	parsedPort, err := strconv.ParseInt(fmt.Sprintf("%d", ins.Port), 10, 32)
+	if err != nil || parsedPort < 0 || parsedPort > math.MaxInt32 {
+		return fmt.Errorf("invalid port value: %v", ins.Port)
+	}
+	port := int32(parsedPort)
 	instanceId := dc.getServiceInstanceID(ins.ServiceName, ins.Ip, connector.MicroServicePort(port), connector.ProtocolHTTP)
 	return dc.connectController.CacheDeregisterInstance(instanceId, func() error {
 		conn := dc.nacosClient(instanceId)
@@ -461,7 +465,11 @@ func (dc *NacosDiscoveryClient) Register(reg *connector.CatalogRegistration) err
 		k2cClusterId = connector.NACOS_DEFAULT_CLUSTER
 	}
 	ins := reg.ToNacos(k2cClusterId, k2cGroupId, float64(1))
-	port, _ := strconv.Atoi(fmt.Sprintf("%d", ins.Port))
+	parsedPort, err := strconv.ParseInt(fmt.Sprintf("%d", ins.Port), 10, 32)
+	if err != nil || parsedPort < 0 || parsedPort > math.MaxInt32 {
+		return fmt.Errorf("invalid port value: %v", ins.Port)
+	}
+	port := int32(parsedPort)
 	instanceId := dc.getServiceInstanceID(ins.ServiceName, ins.Ip, connector.MicroServicePort(port), connector.ProtocolHTTP)
 	return dc.connectController.CacheRegisterInstance(instanceId, ins, func() error {
 		_, err := dc.nacosClient(instanceId).RegisterInstance(*ins)

--- a/pkg/connector/provider/nacos.go
+++ b/pkg/connector/provider/nacos.go
@@ -440,7 +440,7 @@ func (dc *NacosDiscoveryClient) Deregister(dereg *connector.CatalogDeregistratio
 		return nil
 	}
 	parsedPort, err := strconv.ParseInt(fmt.Sprintf("%d", ins.Port), 10, 32)
-	if err != nil || parsedPort < 0 || parsedPort > math.MaxInt32 {
+	if err != nil || parsedPort <= 0 || parsedPort > 65535 {
 		return fmt.Errorf("invalid port value: %v", ins.Port)
 	}
 	port := int32(parsedPort)
@@ -466,7 +466,7 @@ func (dc *NacosDiscoveryClient) Register(reg *connector.CatalogRegistration) err
 	}
 	ins := reg.ToNacos(k2cClusterId, k2cGroupId, float64(1))
 	parsedPort, err := strconv.ParseInt(fmt.Sprintf("%d", ins.Port), 10, 32)
-	if err != nil || parsedPort < 0 || parsedPort > math.MaxInt32 {
+	if err != nil || parsedPort <= 0 || parsedPort > 65535 {
 		return fmt.Errorf("invalid port value: %v", ins.Port)
 	}
 	port := int32(parsedPort)


### PR DESCRIPTION
Potential fix for [https://github.com/flomesh-io/fsm/security/code-scanning/82](https://github.com/flomesh-io/fsm/security/code-scanning/82)

To fix the issue, we need to ensure that the value of `port` is within the valid range for `connector.MicroServicePort` before performing the conversion. This can be achieved by:
1. Using `strconv.ParseInt` with a specified bit size (e.g., 32 bits) to parse the string representation of `ins.Port`.
2. Adding bounds checks to ensure the parsed value is within the valid range for `connector.MicroServicePort` (e.g., `math.MinInt32` to `math.MaxInt32` for a 32-bit integer).
3. Returning an error or a default value if the bounds check fails.

The changes will be applied to the `Deregister` and `Register` methods where the `port` variable is used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
